### PR TITLE
Add Kubernetes Jobs and CronJobs Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-flow-renderer": "^10.3.17"
+        "react-flow-renderer": "^10.3.17",
+        "react-syntax-highlighter": "^15.6.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",
@@ -1352,6 +1354,15 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1396,6 +1407,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resize-observer-browser": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
@@ -1407,6 +1428,12 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1901,6 +1928,36 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1960,6 +2017,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "13.1.0",
@@ -2522,6 +2589,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2639,6 +2719,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fraction.js": {
@@ -2845,6 +2933,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2896,6 +3026,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2921,6 +3075,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -2951,6 +3115,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-number": {
@@ -3142,6 +3316,20 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -3395,6 +3583,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/path-exists": {
@@ -3713,6 +3919,28 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3798,6 +4026,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz",
+      "integrity": "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3817,6 +4062,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/resolve": {
@@ -3982,6 +4251,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/string-width": {
@@ -4624,6 +4903,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-flow-renderer": "^10.3.17"
+    "react-flow-renderer": "^10.3.17",
+    "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Download, FileText, List, Plus, Menu, X, Database, Settings, Key, PlayCircle, Container as Docker, FolderOpen, GitBranch } from 'lucide-react';
+import { Download, FileText, List, Plus, Menu, X, Database, Settings, Key, PlayCircle, Container as Docker, FolderOpen, GitBranch, Clock } from 'lucide-react';
 import { DeploymentForm } from './components/DeploymentForm';
 import { YamlPreview } from './components/YamlPreview';
 import { ResourceSummary } from './components/ResourceSummary';
@@ -1073,8 +1073,13 @@ function App() {
                     </div>
                     <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
                       <JobsIcon className="w-5 h-5 text-pink-500" />
-                      <span className="font-bold">{jobs.length}</span>
-                      <span className="text-gray-500">job{jobs.length !== 1 ? 's' : ''}</span>
+                      <span className="font-bold">{jobs.filter(j => j.type === 'job').length}</span>
+                      <span className="text-gray-500">job{jobs.filter(j => j.type === 'job').length !== 1 ? 's' : ''}</span>
+                    </div>
+                    <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
+                      <Clock className="w-5 h-5 text-yellow-500" />
+                      <span className="font-bold">{jobs.filter(j => j.type === 'cronjob').length}</span>
+                      <span className="text-gray-500">cronjob{jobs.filter(j => j.type === 'cronjob').length !== 1 ? 's' : ''}</span>
                     </div>
                   </div>
                 </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,9 +22,20 @@ import { JobManager, Job } from './components/JobManager';
 import { JobList } from './components/jobs/JobList';
 import { CronJobList } from './components/jobs/CronJobList';
 import type { DeploymentConfig, Namespace, ConfigMap, Secret, ProjectSettings, JobConfig, CronJobConfig } from './types';
+import {
+  K8sDeploymentIcon,
+  K8sNamespaceIcon,
+  K8sConfigMapIcon,
+  K8sSecretIcon,
+  K8sJobIcon,
+  K8sCronJobIcon,
+  K8sStorageIcon,
+  K8sDaemonSetIcon,
+  K8sPodIcon
+} from './components/KubernetesIcons';
 
 type PreviewMode = 'visual' | 'yaml' | 'summary' | 'argocd' | 'flow';
-type SidebarTab = 'deployments' | 'namespaces' | 'storage' | 'jobs';
+type SidebarTab = 'deployments' | 'namespaces' | 'storage' | 'jobs' | 'configmaps' | 'secrets';
 
 function App() {
   const [projectSettings, setProjectSettings] = useState<ProjectSettings>({
@@ -554,22 +565,14 @@ function App() {
     }
   }, []);
 
-  // Placeholder SVG icon components (replace with official K8s SVGs)
-  const DeploymentIcon = () => (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" /><path d="M12 6v6l4 2" stroke="currentColor" /></svg>
-  );
-  const ConfigMapIcon = () => (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="13" rx="2" stroke="currentColor" /><path d="M16 3v4M8 3v4" stroke="currentColor" /></svg>
-  );
-  const SecretIcon = () => (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" /><path d="M12 16v-4M12 8h.01" stroke="currentColor" /></svg>
-  );
-  const StorageIcon = () => (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="9" ry="3" stroke="currentColor" /><path d="M3 6v6c0 1.657 4.03 3 9 3s9-1.343 9-3V6" stroke="currentColor" /><path d="M3 12v6c0 1.657 4.03 3 9 3s9-1.343 9-3v-6" stroke="currentColor" /></svg>
-  );
-  const JobsIcon = ({ className = "w-4 h-4" }: { className?: string }) => (
-    <svg className={className} fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" stroke="currentColor" /><path d="M16 3v4M8 3v4M2 13h20" stroke="currentColor" /></svg>
-  );
+  useEffect(() => {
+    // Ensure the correct group is open based on the selected tab
+    if (sidebarTab === 'storage' || sidebarTab === 'configmaps' || sidebarTab === 'secrets') {
+      setOpenGroup('storage');
+    } else {
+      setOpenGroup('workloads');
+    }
+  }, [sidebarTab]);
 
   // Helper: Map Job (JobManager) to JobConfig (for JobList)
   function jobToJobConfig(job: Job): JobConfig {
@@ -760,39 +763,89 @@ function App() {
             {openGroup === 'workloads' && (
               <div className="pl-6 space-y-1">
                 <button
-                  onClick={() => { setSidebarTab('deployments'); setOpenGroup('workloads'); }}
-                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'deployments' ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 shadow-sm border border-blue-200 dark:border-blue-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                  onClick={() => {
+                    setOpenGroup('workloads');
+                    setSidebarTab('deployments');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'deployments' 
+                      ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 shadow-sm border border-blue-100 dark:border-blue-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-blue-50/50 dark:hover:bg-blue-900/10 hover:text-blue-600 dark:hover:text-blue-300'
+                  }`}
                 >
-                  <DeploymentIcon />
-                  <span>Deployments</span>
+                  <K8sDeploymentIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'deployments' ? 'text-blue-600 dark:text-blue-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  Deployments
                 </button>
+
                 <button
-                  onClick={() => { setSidebarTab('jobs'); setJobsSubTab('jobs'); setOpenGroup('workloads'); }}
-                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'jobs' && jobsSubTab === 'jobs' ? 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-300 shadow-sm border border-pink-200 dark:border-pink-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                  onClick={() => {
+                    setOpenGroup('workloads');
+                    setSidebarTab('namespaces');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'namespaces' 
+                      ? 'bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-300 shadow-sm border border-purple-100 dark:border-purple-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-purple-50/50 dark:hover:bg-purple-900/10 hover:text-purple-600 dark:hover:text-purple-300'
+                  }`}
                 >
-                  <JobsIcon className="w-4 h-4" />
-                  <span>Jobs</span>
+                  <K8sNamespaceIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'namespaces' ? 'text-purple-600 dark:text-purple-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  Namespaces
                 </button>
-                <button
-                  onClick={() => { setSidebarTab('jobs'); setJobsSubTab('cronjobs'); setOpenGroup('workloads'); }}
-                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'jobs' && jobsSubTab === 'cronjobs' ? 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 shadow-sm border border-yellow-200 dark:border-yellow-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
-                >
-                  <JobsIcon className="w-4 h-4" />
-                  <span>CronJobs</span>
-                </button>
+
                 <button
                   disabled
-                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 cursor-not-allowed bg-gray-50 dark:bg-gray-800"
+                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
                 >
-                  <JobsIcon className="w-4 h-4" />
-                  <span>DaemonSets</span>
+                  <K8sDaemonSetIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
+                  DaemonSets
                 </button>
+
+                <button
+                  onClick={() => {
+                    setOpenGroup('workloads');
+                    setSidebarTab('jobs');
+                    setJobsSubTab('jobs');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'jobs' && jobsSubTab === 'jobs'
+                      ? 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-300 shadow-sm border border-pink-100 dark:border-pink-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-pink-50/50 dark:hover:bg-pink-900/10 hover:text-pink-600 dark:hover:text-pink-300'
+                  }`}
+                >
+                  <K8sJobIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'jobs' && jobsSubTab === 'jobs' ? 'text-pink-600 dark:text-pink-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  Jobs
+                </button>
+
+                <button
+                  onClick={() => {
+                    setOpenGroup('workloads');
+                    setSidebarTab('jobs');
+                    setJobsSubTab('cronjobs');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'jobs' && jobsSubTab === 'cronjobs'
+                      ? 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 shadow-sm border border-yellow-100 dark:border-yellow-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-yellow-50/50 dark:hover:bg-yellow-900/10 hover:text-yellow-600 dark:hover:text-yellow-300'
+                  }`}
+                >
+                  <K8sCronJobIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'jobs' && jobsSubTab === 'cronjobs' ? 'text-yellow-600 dark:text-yellow-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  CronJobs
+                </button>
+
                 <button
                   disabled
-                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 cursor-not-allowed bg-gray-50 dark:bg-gray-800"
+                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
                 >
-                  <JobsIcon className="w-4 h-4" />
-                  <span>Pods</span>
+                  <K8sPodIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
+                  Pods
                 </button>
               </div>
             )}
@@ -803,7 +856,7 @@ function App() {
               aria-expanded={openGroup === 'storage'}
             >
               <span className="flex items-center gap-2">
-                <StorageIcon />
+                <K8sStorageIcon className="w-4 h-4 text-blue-600" />
                 Storage
               </span>
               <span>{openGroup === 'storage' ? '▾' : '▸'}</span>
@@ -811,42 +864,61 @@ function App() {
             {openGroup === 'storage' && (
               <div className="pl-6 space-y-1">
                 <button
-                  onClick={() => { setSidebarTab('storage'); setStorageSubTab('configmaps'); setOpenGroup('storage'); }}
-                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'storage' && storageSubTab === 'configmaps' ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-200 dark:border-green-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                  onClick={() => {
+                    setSidebarTab('storage');
+                    setStorageSubTab('configmaps');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'storage' && storageSubTab === 'configmaps'
+                      ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-100 dark:border-green-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-green-50/50 dark:hover:bg-green-900/10 hover:text-green-600 dark:hover:text-green-300'
+                  }`}
                 >
-                  <ConfigMapIcon />
-                  <span>ConfigMaps</span>
+                  <K8sConfigMapIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'storage' && storageSubTab === 'configmaps' ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  ConfigMaps
                 </button>
                 <button
-                  onClick={() => { setSidebarTab('storage'); setStorageSubTab('secrets'); setOpenGroup('storage'); }}
-                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'storage' && storageSubTab === 'secrets' ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-200 dark:border-green-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                  onClick={() => {
+                    setSidebarTab('storage');
+                    setStorageSubTab('secrets');
+                  }}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'storage' && storageSubTab === 'secrets'
+                      ? 'bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-300 shadow-sm border border-orange-100 dark:border-orange-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-orange-50/50 dark:hover:bg-orange-900/10 hover:text-orange-600 dark:hover:text-orange-300'
+                  }`}
                 >
-                  <SecretIcon />
-                  <span>Secrets</span>
+                  <K8sSecretIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'storage' && storageSubTab === 'secrets' ? 'text-orange-600 dark:text-orange-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  Secrets
                 </button>
+
+                {/* Add back the disabled storage items */}
                 <button
-                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
                   disabled
-                  aria-disabled="true"
+                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
                 >
-                  <StorageIcon />
-                  <span>PersistentVolumes</span>
+                  <K8sStorageIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
+                  PersistentVolumes
                 </button>
+
                 <button
-                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
                   disabled
-                  aria-disabled="true"
+                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
                 >
-                  <StorageIcon />
-                  <span>PersistentVolumeClaims</span>
+                  <K8sStorageIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
+                  PersistentVolumeClaims
                 </button>
+
                 <button
-                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
                   disabled
-                  aria-disabled="true"
+                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
                 >
-                  <StorageIcon />
-                  <span>StorageClasses</span>
+                  <K8sStorageIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
+                  StorageClasses
                 </button>
               </div>
             )}
@@ -1072,7 +1144,7 @@ function App() {
                       <span className="text-gray-500">secret{secrets.length !== 1 ? 's' : ''}</span>
                     </div>
                     <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
-                      <JobsIcon className="w-5 h-5 text-pink-500" />
+                      <K8sJobIcon className="w-5 h-5 text-pink-500" />
                       <span className="font-bold">{jobs.filter(j => j.type === 'job').length}</span>
                       <span className="text-gray-500">job{jobs.filter(j => j.type === 'job').length !== 1 ? 's' : ''}</span>
                     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App() {
   const [selectedNamespace, setSelectedNamespace] = useState<number>(0);
   const [selectedConfigMap, setSelectedConfigMap] = useState<number>(0);
   const [selectedSecret, setSelectedSecret] = useState<number>(0);
-  const [previewMode, setPreviewMode] = useState<PreviewMode>('yaml');
+  const [previewMode, setPreviewMode] = useState<PreviewMode>('flow');
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('deployments');
   const [storageSubTab, setStorageSubTab] = useState<'configmaps' | 'secrets'>('configmaps');
   const [jobsSubTab, setJobsSubTab] = useState<'jobs' | 'cronjobs'>('jobs');
@@ -76,9 +76,7 @@ function App() {
   const [showYouTubePopup, setShowYouTubePopup] = useState(false);
   const [showDockerPopup, setShowDockerPopup] = useState(false);
   // Only one group open at a time: 'workloads' | 'storage'
-  const [openGroup, setOpenGroup] = useState<'workloads' | 'storage'>(
-    sidebarTab === 'storage' ? 'storage' : 'workloads'
-  );
+  const [openGroup, setOpenGroup] = useState<'workloads' | 'storage'>('workloads');
   const [jobToEdit, setJobToEdit] = useState<Job | undefined>(undefined);
   const [selectedJob, setSelectedJob] = useState<number>(-1);
   const [selectedCronJob, setSelectedCronJob] = useState<number>(-1);
@@ -608,6 +606,29 @@ function App() {
     };
   }
 
+  // Function to handle menu item clicks and set appropriate preview mode
+  const handleMenuClick = (tab: SidebarTab, subTab?: string) => {
+    setSidebarTab(tab);
+    
+    // Set preview mode based on the selected tab
+    if (tab === 'deployments') {
+      setPreviewMode('flow');
+    } else {
+      setPreviewMode('yaml');
+    }
+    
+    // Handle sub-tabs
+    if (subTab === 'configmaps') {
+      setStorageSubTab('configmaps');
+    } else if (subTab === 'secrets') {
+      setStorageSubTab('secrets');
+    } else if (subTab === 'jobs') {
+      setJobsSubTab('jobs');
+    } else if (subTab === 'cronjobs') {
+      setJobsSubTab('cronjobs');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* SEO Head Component */}
@@ -763,10 +784,7 @@ function App() {
             {openGroup === 'workloads' && (
               <div className="pl-6 space-y-1">
                 <button
-                  onClick={() => {
-                    setOpenGroup('workloads');
-                    setSidebarTab('deployments');
-                  }}
+                  onClick={() => handleMenuClick('deployments')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'deployments' 
                       ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 shadow-sm border border-blue-100 dark:border-blue-800' 
@@ -780,10 +798,7 @@ function App() {
                 </button>
 
                 <button
-                  onClick={() => {
-                    setOpenGroup('workloads');
-                    setSidebarTab('namespaces');
-                  }}
+                  onClick={() => handleMenuClick('namespaces')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'namespaces' 
                       ? 'bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-300 shadow-sm border border-purple-100 dark:border-purple-800' 
@@ -805,11 +820,7 @@ function App() {
                 </button>
 
                 <button
-                  onClick={() => {
-                    setOpenGroup('workloads');
-                    setSidebarTab('jobs');
-                    setJobsSubTab('jobs');
-                  }}
+                  onClick={() => handleMenuClick('jobs', 'jobs')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'jobs' && jobsSubTab === 'jobs'
                       ? 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-300 shadow-sm border border-pink-100 dark:border-pink-800' 
@@ -823,11 +834,7 @@ function App() {
                 </button>
 
                 <button
-                  onClick={() => {
-                    setOpenGroup('workloads');
-                    setSidebarTab('jobs');
-                    setJobsSubTab('cronjobs');
-                  }}
+                  onClick={() => handleMenuClick('jobs', 'cronjobs')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'jobs' && jobsSubTab === 'cronjobs'
                       ? 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 shadow-sm border border-yellow-100 dark:border-yellow-800' 
@@ -864,10 +871,7 @@ function App() {
             {openGroup === 'storage' && (
               <div className="pl-6 space-y-1">
                 <button
-                  onClick={() => {
-                    setSidebarTab('storage');
-                    setStorageSubTab('configmaps');
-                  }}
+                  onClick={() => handleMenuClick('storage', 'configmaps')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'storage' && storageSubTab === 'configmaps'
                       ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-100 dark:border-green-800' 
@@ -880,10 +884,7 @@ function App() {
                   ConfigMaps
                 </button>
                 <button
-                  onClick={() => {
-                    setSidebarTab('storage');
-                    setStorageSubTab('secrets');
-                  }}
+                  onClick={() => handleMenuClick('storage', 'secrets')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'storage' && storageSubTab === 'secrets'
                       ? 'bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-300 shadow-sm border border-orange-100 dark:border-orange-800' 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,13 @@ import { ProjectSettingsManager } from './components/ProjectSettingsManager';
 import { YouTubePopup } from './components/YouTubePopup';
 import { DockerRunPopup } from './components/DockerRunPopup';
 import { generateMultiDeploymentYaml } from './utils/yamlGenerator';
-import type { DeploymentConfig, Namespace, ConfigMap, Secret, ProjectSettings } from './types';
+import { JobManager, Job } from './components/JobManager';
+import { JobList } from './components/jobs/JobList';
+import { CronJobList } from './components/jobs/CronJobList';
+import type { DeploymentConfig, Namespace, ConfigMap, Secret, ProjectSettings, JobConfig, CronJobConfig } from './types';
 
 type PreviewMode = 'visual' | 'yaml' | 'summary' | 'argocd' | 'flow';
-type SidebarTab = 'deployments' | 'namespaces' | 'configmaps' | 'secrets';
+type SidebarTab = 'deployments' | 'namespaces' | 'storage' | 'jobs';
 
 function App() {
   const [projectSettings, setProjectSettings] = useState<ProjectSettings>({
@@ -42,20 +45,32 @@ function App() {
   ]);
   const [configMaps, setConfigMaps] = useState<ConfigMap[]>([]);
   const [secrets, setSecrets] = useState<Secret[]>([]);
+  const [jobs, setJobs] = useState<Job[]>([]);
   const [selectedDeployment, setSelectedDeployment] = useState<number>(0);
   const [selectedNamespace, setSelectedNamespace] = useState<number>(0);
   const [selectedConfigMap, setSelectedConfigMap] = useState<number>(0);
   const [selectedSecret, setSelectedSecret] = useState<number>(0);
-  const [previewMode, setPreviewMode] = useState<PreviewMode>('flow');
+  const [previewMode, setPreviewMode] = useState<PreviewMode>('yaml');
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('deployments');
+  const [storageSubTab, setStorageSubTab] = useState<'configmaps' | 'secrets'>('configmaps');
+  const [jobsSubTab, setJobsSubTab] = useState<'jobs' | 'cronjobs'>('jobs');
   const [showForm, setShowForm] = useState(false);
   const [showNamespaceManager, setShowNamespaceManager] = useState(false);
   const [showConfigMapManager, setShowConfigMapManager] = useState(false);
   const [showSecretManager, setShowSecretManager] = useState(false);
+  const [showJobManager, setShowJobManager] = useState(false);
+  const [jobTypeToCreate, setJobTypeToCreate] = useState<'job' | 'cronjob'>('job');
   const [showProjectSettings, setShowProjectSettings] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showYouTubePopup, setShowYouTubePopup] = useState(false);
   const [showDockerPopup, setShowDockerPopup] = useState(false);
+  // Only one group open at a time: 'workloads' | 'storage'
+  const [openGroup, setOpenGroup] = useState<'workloads' | 'storage'>(
+    sidebarTab === 'storage' ? 'storage' : 'workloads'
+  );
+  const [jobToEdit, setJobToEdit] = useState<Job | undefined>(undefined);
+  const [selectedJob, setSelectedJob] = useState<number>(-1);
+  const [selectedCronJob, setSelectedCronJob] = useState<number>(-1);
 
   const currentConfig = deployments[selectedDeployment] || {
     appName: '',
@@ -288,7 +303,8 @@ function App() {
     };
     setConfigMaps([...configMaps, configMapWithGlobalLabels]);
     setShowConfigMapManager(false);
-    setSidebarTab('configmaps');
+    setSidebarTab('storage');
+    setStorageSubTab('configmaps');
     setSelectedConfigMap(configMaps.length);
   };
 
@@ -333,7 +349,8 @@ function App() {
     };
     setSecrets([...secrets, secretWithGlobalLabels]);
     setShowSecretManager(false);
-    setSidebarTab('secrets');
+    setSidebarTab('storage');
+    setStorageSubTab('secrets');
     setSelectedSecret(secrets.length);
   };
 
@@ -364,14 +381,61 @@ function App() {
     const duplicatedSecret: Secret = {
       ...secretToDuplicate,
       name: `${secretToDuplicate.name}-copy`,
-      labels: cleanAndMergeLabels(secretToDuplicate.labels),
       createdAt: new Date().toISOString()
     };
+    setSecrets([...secrets, duplicatedSecret]);
+    setSelectedSecret(secrets.length);
+  };
+
+  // Job management functions
+  const handleAddJob = (job: Job) => {
+    // Convert job labels from array to object format for global label merging
+    const jobLabelsAsObject = job.labels.reduce((acc, label) => {
+      if (label.key) acc[label.key] = label.value;
+      return acc;
+    }, {} as Record<string, string>);
     
-    const newSecrets = [...secrets];
-    newSecrets.splice(index + 1, 0, duplicatedSecret);
-    setSecrets(newSecrets);
-    setSelectedSecret(index + 1);
+    // Apply global labels
+    const mergedLabels = cleanAndMergeLabels(jobLabelsAsObject);
+    
+    // Convert back to array format for Job interface
+    const jobWithGlobalLabels = {
+      ...job,
+      labels: Object.entries(mergedLabels).map(([key, value]) => ({ key, value }))
+    };
+    setJobs(prev => [...prev, jobWithGlobalLabels]);
+  };
+
+  const handleDeleteJob = (jobId: string) => {
+    setJobs(jobs.filter(j => j.id !== jobId));
+  };
+
+  const handleEditJob = (jobId: string) => {
+    const job = jobs.find(j => j.id === jobId);
+    if (job) {
+      setJobToEdit(job);
+      setShowJobManager(true);
+    }
+  };
+
+  const handleUpdateJob = (jobId: string, updatedJob: Job) => {
+    // Convert job labels from array to object format for global label merging
+    const jobLabelsAsObject = updatedJob.labels.reduce((acc, label) => {
+      if (label.key) acc[label.key] = label.value;
+      return acc;
+    }, {} as Record<string, string>);
+    
+    // Apply global labels
+    const mergedLabels = cleanAndMergeLabels(jobLabelsAsObject);
+    
+    // Convert back to array format for Job interface
+    const jobWithGlobalLabels = {
+      ...updatedJob,
+      labels: Object.entries(mergedLabels).map(([key, value]) => ({ key, value }))
+    };
+    setJobs(jobs.map(j => j.id === jobId ? jobWithGlobalLabels : j));
+    setJobToEdit(undefined);
+    setShowJobManager(false);
   };
 
   // Project settings management
@@ -403,6 +467,25 @@ function App() {
       labels: cleanAndMergeLabels(secret.labels, oldGlobalLabels, newSettings.globalLabels, newSettings.name)
     }));
     setSecrets(updatedSecrets);
+
+    // Update jobs with new global labels
+    const updatedJobs = jobs.map(job => {
+      // Convert job labels from array to object format
+      const jobLabelsAsObject = job.labels.reduce((acc, label) => {
+        if (label.key) acc[label.key] = label.value;
+        return acc;
+      }, {} as Record<string, string>);
+      
+      // Apply new global labels
+      const mergedLabels = cleanAndMergeLabels(jobLabelsAsObject, oldGlobalLabels, newSettings.globalLabels, newSettings.name);
+      
+      // Convert back to array format
+      return {
+        ...job,
+        labels: Object.entries(mergedLabels).map(([key, value]) => ({ key, value }))
+      };
+    });
+    setJobs(updatedJobs);
   };
 
   const handleDownload = async () => {
@@ -436,12 +519,22 @@ function App() {
 
   // Generate YAML for preview based on mode
   const getPreviewYaml = () => {
-    if (deployments.length === 0 && namespaces.length <= 1 && configMaps.length === 0 && secrets.length === 0) {
-      return '# No deployments configured\n# Create your first deployment to see the generated YAML';
-    }
-    
     const validDeployments = deployments.filter(d => d.appName);
-    return generateMultiDeploymentYaml(validDeployments, namespaces, configMaps, secrets, projectSettings);
+    // Fix: Only map regular jobs to jobConfigs, not cronjobs
+    const jobConfigs = jobs.filter(j => j.type === 'job').map(jobToJobConfig);
+    const cronJobConfigs = jobs.filter(j => j.type === 'cronjob').map(jobToCronJobConfig);
+    const yaml = generateMultiDeploymentYaml(validDeployments, namespaces, configMaps, secrets, projectSettings, jobConfigs, cronJobConfigs);
+    if (
+      validDeployments.length === 0 &&
+      jobConfigs.length === 0 &&
+      cronJobConfigs.length === 0 &&
+      namespaces.length <= 1 &&
+      configMaps.length === 0 &&
+      secrets.length === 0
+    ) {
+      return '# No deployments or jobs configured\n# Create your first deployment or job to see the generated YAML';
+    }
+    return yaml;
   };
 
   const previewModes = [
@@ -460,6 +553,57 @@ function App() {
       containerRef.current.scrollLeft = 0; // or center calculation
     }
   }, []);
+
+  // Placeholder SVG icon components (replace with official K8s SVGs)
+  const DeploymentIcon = () => (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" /><path d="M12 6v6l4 2" stroke="currentColor" /></svg>
+  );
+  const ConfigMapIcon = () => (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="13" rx="2" stroke="currentColor" /><path d="M16 3v4M8 3v4" stroke="currentColor" /></svg>
+  );
+  const SecretIcon = () => (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" /><path d="M12 16v-4M12 8h.01" stroke="currentColor" /></svg>
+  );
+  const StorageIcon = () => (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="9" ry="3" stroke="currentColor" /><path d="M3 6v6c0 1.657 4.03 3 9 3s9-1.343 9-3V6" stroke="currentColor" /><path d="M3 12v6c0 1.657 4.03 3 9 3s9-1.343 9-3v-6" stroke="currentColor" /></svg>
+  );
+  const JobsIcon = ({ className = "w-4 h-4" }: { className?: string }) => (
+    <svg className={className} fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" stroke="currentColor" /><path d="M16 3v4M8 3v4M2 13h20" stroke="currentColor" /></svg>
+  );
+
+  // Helper: Map Job (JobManager) to JobConfig (for JobList)
+  function jobToJobConfig(job: Job): JobConfig {
+    return {
+      name: job.name || 'unnamed-job',
+      namespace: job.namespace || 'default',
+      labels: job.labels && Array.isArray(job.labels)
+        ? job.labels.reduce((acc, l) => l.key ? { ...acc, [l.key]: l.value } : acc, {})
+        : (job.labels || {}),
+      annotations: {},
+      containers: job.containers && job.containers.length > 0 ? job.containers : [{ name: 'main', image: 'nginx', resources: { requests: { cpu: '100m', memory: '128Mi' }, limits: { cpu: '', memory: '' } }, env: [], volumeMounts: [] }],
+      restartPolicy: job.restartPolicy || 'Never',
+      completions: job.completions || 1,
+      parallelism: job.replicas || 1,
+      backoffLimit: job.backoffLimit || 6,
+      activeDeadlineSeconds: job.activeDeadlineSeconds,
+    };
+  }
+  // Helper: Map Job (JobManager) to CronJobConfig (for CronJobList)
+  function jobToCronJobConfig(job: Job): CronJobConfig {
+    return {
+      name: job.name,
+      namespace: job.namespace,
+      labels: {},
+      annotations: {},
+      schedule: job.schedule || '',
+      concurrencyPolicy: job.concurrencyPolicy,
+      startingDeadlineSeconds: job.startingDeadline ? parseInt(job.startingDeadline) : undefined,
+      successfulJobsHistoryLimit: job.historySuccess ? parseInt(job.historySuccess) : undefined,
+      failedJobsHistoryLimit: job.historyFailure ? parseInt(job.historyFailure) : undefined,
+      jobTemplate: jobToJobConfig(job),
+      createdAt: undefined,
+    };
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
@@ -505,14 +649,6 @@ function App() {
                 </div>
                 <div className="flex flex-col space-y-2 w-full">
                   <button
-                    onClick={handleAddDeployment}
-                    className="inline-flex items-center justify-center px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 text-sm font-medium w-full max-w-sm mx-auto"
-                    title="Add new deployment"
-                  >
-                    <Plus className="w-4 h-4 mr-1" />
-                    <span>Add Deployment</span>
-                  </button>
-                  <button
                     onClick={() => setShowDockerPopup(true)}
                     className="inline-flex items-center justify-center px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 text-sm font-medium w-full max-w-sm mx-auto"
                     title="Run locally with Docker"
@@ -543,14 +679,6 @@ function App() {
             {/* Desktop: SocialShare inline + actions inline */}
             <div className="hidden sm:flex flex-row items-center space-x-2">
               <SocialShare />
-              <button
-                onClick={handleAddDeployment}
-                className="inline-flex items-center justify-center px-2 sm:px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 text-sm font-medium"
-                title="Add new deployment"
-              >
-                <Plus className="w-4 h-4 mr-1" />
-                <span>Add Deployment</span>
-              </button>
               <button
                 onClick={() => setShowDockerPopup(true)}
                 className="inline-flex items-center justify-center px-2 sm:px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 text-sm font-medium"
@@ -615,89 +743,152 @@ function App() {
             )}
           </div>
 
-          {/* Tab Headers */}
-          <div className="p-4 border-b border-gray-200 flex-shrink-0">
-            <div className="grid grid-cols-2 gap-1 bg-gray-100 rounded-lg p-1">
-              <button
-                onClick={() => setSidebarTab('deployments')}
-                className={`flex items-center justify-center space-x-1 px-2 py-2 rounded-md text-xs font-medium transition-all duration-200 ${
-                  sidebarTab === 'deployments'
-                    ? 'bg-white text-blue-600 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <FileText className="w-3 h-3" />
-                <span>Deployments</span>
-              </button>
-              <button
-                onClick={() => setSidebarTab('namespaces')}
-                className={`flex items-center justify-center space-x-1 px-2 py-2 rounded-md text-xs font-medium transition-all duration-200 ${
-                  sidebarTab === 'namespaces'
-                    ? 'bg-white text-purple-600 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <Database className="w-3 h-3" />
-                <span>Namespaces</span>
-              </button>
-              <button
-                onClick={() => setSidebarTab('configmaps')}
-                className={`flex items-center justify-center space-x-1 px-2 py-2 rounded-md text-xs font-medium transition-all duration-200 ${
-                  sidebarTab === 'configmaps'
-                    ? 'bg-white text-green-600 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <Settings className="w-3 h-3" />
-                <span>ConfigMaps</span>
-              </button>
-              <button
-                onClick={() => setSidebarTab('secrets')}
-                className={`flex items-center justify-center space-x-1 px-2 py-2 rounded-md text-xs font-medium transition-all duration-200 ${
-                  sidebarTab === 'secrets'
-                    ? 'bg-white text-orange-600 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <Key className="w-3 h-3" />
-                <span>Secrets</span>
-              </button>
-            </div>
+          {/* Grouped Sidebar Menu */}
+          <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0 space-y-2">
+            {/* Workloads Group */}
+            <button
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200"
+              onClick={() => setOpenGroup('workloads')}
+              aria-expanded={openGroup === 'workloads'}
+            >
+              <span className="flex items-center gap-2">
+                <Database className="w-4 h-4 text-blue-600" />
+                Workloads
+              </span>
+              <span>{openGroup === 'workloads' ? '▾' : '▸'}</span>
+            </button>
+            {openGroup === 'workloads' && (
+              <div className="pl-6 space-y-1">
+                <button
+                  onClick={() => { setSidebarTab('deployments'); setOpenGroup('workloads'); }}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'deployments' ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 shadow-sm border border-blue-200 dark:border-blue-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                >
+                  <DeploymentIcon />
+                  <span>Deployments</span>
+                </button>
+                <button
+                  onClick={() => { setSidebarTab('jobs'); setJobsSubTab('jobs'); setOpenGroup('workloads'); }}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'jobs' && jobsSubTab === 'jobs' ? 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-300 shadow-sm border border-pink-200 dark:border-pink-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                >
+                  <JobsIcon className="w-4 h-4" />
+                  <span>Jobs</span>
+                </button>
+                <button
+                  onClick={() => { setSidebarTab('jobs'); setJobsSubTab('cronjobs'); setOpenGroup('workloads'); }}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'jobs' && jobsSubTab === 'cronjobs' ? 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 shadow-sm border border-yellow-200 dark:border-yellow-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                >
+                  <JobsIcon className="w-4 h-4" />
+                  <span>CronJobs</span>
+                </button>
+                <button
+                  disabled
+                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 cursor-not-allowed bg-gray-50 dark:bg-gray-800"
+                >
+                  <JobsIcon className="w-4 h-4" />
+                  <span>DaemonSets</span>
+                </button>
+                <button
+                  disabled
+                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 cursor-not-allowed bg-gray-50 dark:bg-gray-800"
+                >
+                  <JobsIcon className="w-4 h-4" />
+                  <span>Pods</span>
+                </button>
+              </div>
+            )}
+            {/* Storage Group */}
+            <button
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200"
+              onClick={() => setOpenGroup('storage')}
+              aria-expanded={openGroup === 'storage'}
+            >
+              <span className="flex items-center gap-2">
+                <StorageIcon />
+                Storage
+              </span>
+              <span>{openGroup === 'storage' ? '▾' : '▸'}</span>
+            </button>
+            {openGroup === 'storage' && (
+              <div className="pl-6 space-y-1">
+                <button
+                  onClick={() => { setSidebarTab('storage'); setStorageSubTab('configmaps'); setOpenGroup('storage'); }}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'storage' && storageSubTab === 'configmaps' ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-200 dark:border-green-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                >
+                  <ConfigMapIcon />
+                  <span>ConfigMaps</span>
+                </button>
+                <button
+                  onClick={() => { setSidebarTab('storage'); setStorageSubTab('secrets'); setOpenGroup('storage'); }}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${sidebarTab === 'storage' && storageSubTab === 'secrets' ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300 shadow-sm border border-green-200 dark:border-green-800' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'}`}
+                >
+                  <SecretIcon />
+                  <span>Secrets</span>
+                </button>
+                <button
+                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
+                  disabled
+                  aria-disabled="true"
+                >
+                  <StorageIcon />
+                  <span>PersistentVolumes</span>
+                </button>
+                <button
+                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
+                  disabled
+                  aria-disabled="true"
+                >
+                  <StorageIcon />
+                  <span>PersistentVolumeClaims</span>
+                </button>
+                <button
+                  className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed"
+                  disabled
+                  aria-disabled="true"
+                >
+                  <StorageIcon />
+                  <span>StorageClasses</span>
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Tab Content */}
           <div className="flex-1 min-h-0 overflow-y-auto">
             {sidebarTab === 'deployments' && (
-              deployments.length > 0 ? (
-                <DeploymentsList
-                  deployments={deployments}
-                  selectedIndex={selectedDeployment}
-                  onSelect={(index) => {
-                    setSelectedDeployment(index);
-                    setSidebarOpen(false);
-                  }}
-                  onEdit={() => setShowForm(true)}
-                  onDelete={handleDeleteDeployment}
-                  onDuplicate={handleDuplicateDeployment}
-                />
-              ) : (
-                <div className="p-6 text-center">
-                  <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <FileText className="w-8 h-8 text-gray-400" />
-                  </div>
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">No Deployments</h3>
-                  <p className="text-sm text-gray-500 mb-4">
-                    Get started by creating your first Kubernetes deployment
-                  </p>
+              <div>
+                <div className="p-4 border-b border-gray-200 dark:border-gray-700">
                   <button
                     onClick={handleAddDeployment}
-                    className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 text-sm font-medium"
+                    className="w-full inline-flex items-center justify-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 text-sm font-medium"
                   >
                     <Plus className="w-4 h-4 mr-2" />
-                    Create Deployment
+                    Add Deployment
                   </button>
                 </div>
-              )
+                {deployments.length > 0 ? (
+                  <DeploymentsList
+                    deployments={deployments}
+                    selectedIndex={selectedDeployment}
+                    onSelect={(index) => {
+                      setSelectedDeployment(index);
+                      setSidebarOpen(false);
+                    }}
+                    onEdit={() => setShowForm(true)}
+                    onDelete={handleDeleteDeployment}
+                    onDuplicate={handleDuplicateDeployment}
+                  />
+                ) : (
+                  <div className="p-6 text-center">
+                    <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                      <FileText className="w-8 h-8 text-gray-400" />
+                    </div>
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">No Deployments</h3>
+                    <p className="text-sm text-gray-500 mb-4">
+                      Get started by creating your first Kubernetes deployment
+                    </p>
+                  </div>
+                )}
+              </div>
             )}
 
             {sidebarTab === 'namespaces' && (
@@ -725,54 +916,120 @@ function App() {
               </div>
             )}
 
-            {sidebarTab === 'configmaps' && (
-              <div className="space-y-4">
-                <div className="p-4 border-b border-gray-200">
-                  <button
-                    onClick={() => setShowConfigMapManager(true)}
-                    className="w-full inline-flex items-center justify-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 text-sm font-medium"
-                  >
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add ConfigMap
-                  </button>
-                </div>
-                <ConfigMapsList
-                  configMaps={configMaps}
-                  selectedIndex={selectedConfigMap}
-                  onSelect={(index) => {
-                    setSelectedConfigMap(index);
-                    setSidebarOpen(false);
-                  }}
-                  onEdit={() => setShowConfigMapManager(true)}
-                  onDelete={handleDeleteConfigMap}
-                  onDuplicate={handleDuplicateConfigMap}
-                />
-              </div>
+            {sidebarTab === 'storage' && (
+              <>
+                {storageSubTab === 'configmaps' && (
+                  <>
+                    <div className="p-4 border-b border-gray-200">
+                      <button
+                        onClick={() => setShowConfigMapManager(true)}
+                        className="w-full inline-flex items-center justify-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 text-sm font-medium"
+                      >
+                        <Plus className="w-4 h-4 mr-2" />
+                        Add ConfigMap
+                      </button>
+                    </div>
+                    <ConfigMapsList
+                      configMaps={configMaps}
+                      selectedIndex={selectedConfigMap}
+                      onSelect={(index) => {
+                        setSelectedConfigMap(index);
+                        setSidebarOpen(false);
+                      }}
+                      onEdit={() => setShowConfigMapManager(true)}
+                      onDelete={handleDeleteConfigMap}
+                      onDuplicate={handleDuplicateConfigMap}
+                    />
+                  </>
+                )}
+                {storageSubTab === 'secrets' && (
+                  <>
+                    <div className="p-4 border-b border-gray-200">
+                      <button
+                        onClick={() => setShowSecretManager(true)}
+                        className="w-full inline-flex items-center justify-center px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-colors duration-200 text-sm font-medium"
+                      >
+                        <Plus className="w-4 h-4 mr-2" />
+                        Add Secret
+                      </button>
+                    </div>
+                    <SecretsList
+                      secrets={secrets}
+                      selectedIndex={selectedSecret}
+                      onSelect={(index) => {
+                        setSelectedSecret(index);
+                        setSidebarOpen(false);
+                      }}
+                      onEdit={() => setShowSecretManager(true)}
+                      onDelete={handleDeleteSecret}
+                      onDuplicate={handleDuplicateSecret}
+                    />
+                  </>
+                )}
+              </>
             )}
 
-            {sidebarTab === 'secrets' && (
-              <div className="space-y-4">
-                <div className="p-4 border-b border-gray-200">
-                  <button
-                    onClick={() => setShowSecretManager(true)}
-                    className="w-full inline-flex items-center justify-center px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-colors duration-200 text-sm font-medium"
-                  >
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add Secret
-                  </button>
-                </div>
-                <SecretsList
-                  secrets={secrets}
-                  selectedIndex={selectedSecret}
-                  onSelect={(index) => {
-                    setSelectedSecret(index);
-                    setSidebarOpen(false);
-                  }}
-                  onEdit={() => setShowSecretManager(true)}
-                  onDelete={handleDeleteSecret}
-                  onDuplicate={handleDuplicateSecret}
-                />
-              </div>
+            {sidebarTab === 'jobs' && (
+              <>
+                {jobsSubTab === 'jobs' && (
+                  <>
+                    <JobList
+                      jobs={jobs.filter(j => j.type === 'job').map(jobToJobConfig)}
+                      selectedIndex={selectedJob}
+                      onSelect={setSelectedJob}
+                      onDelete={idx => {
+                        const job = jobs.filter(j => j.type === 'job')[idx];
+                        if (job) handleDeleteJob(job.id);
+                      }}
+                      onEdit={idx => {
+                        const job = jobs.filter(j => j.type === 'job')[idx];
+                        if (job) handleEditJob(job.id);
+                      }}
+                    />
+                    <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+                      <button
+                        onClick={() => {
+                          setJobTypeToCreate('job');
+                          setShowJobManager(true);
+                        }}
+                        className="w-full inline-flex items-center justify-center px-4 py-2 bg-pink-600 text-white rounded-lg hover:bg-pink-700 transition-colors duration-200 text-sm font-medium"
+                      >
+                        <Plus className="w-4 h-4 mr-2" />
+                        Add Job
+                      </button>
+                    </div>
+                  </>
+                )}
+                {jobsSubTab === 'cronjobs' && (
+                  <>
+                    <CronJobList
+                      cronjobs={jobs.filter(j => j.type === 'cronjob').map(jobToCronJobConfig)}
+                      selectedIndex={selectedCronJob}
+                      onSelect={setSelectedCronJob}
+                      onDelete={idx => {
+                        const job = jobs.filter(j => j.type === 'cronjob')[idx];
+                        if (job) handleDeleteJob(job.id);
+                      }}
+                      onEdit={idx => {
+                        const job = jobs.filter(j => j.type === 'cronjob')[idx];
+                        if (job) handleEditJob(job.id);
+                      }}
+                    />
+                    <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+                      <button
+                        onClick={() => {
+                          setJobTypeToCreate('cronjob');
+                          setShowJobManager(true);
+                        }}
+                        className="w-full inline-flex items-center justify-center px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors duration-200 text-sm font-medium"
+                      >
+                        <Plus className="w-4 h-4 mr-2" />
+                        Add CronJob
+                      </button>
+                    </div>
+                  </>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -813,6 +1070,11 @@ function App() {
                       <Key className="w-5 h-5 text-orange-500" />
                       <span className="font-bold">{secrets.length}</span>
                       <span className="text-gray-500">secret{secrets.length !== 1 ? 's' : ''}</span>
+                    </div>
+                    <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
+                      <JobsIcon className="w-5 h-5 text-pink-500" />
+                      <span className="font-bold">{jobs.length}</span>
+                      <span className="text-gray-500">job{jobs.length !== 1 ? 's' : ''}</span>
                     </div>
                   </div>
                 </div>
@@ -876,42 +1138,34 @@ function App() {
       {/* Deployment Form Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
-            {/* Modal Header */}
-            <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
-              <h3 className="text-xl font-semibold text-gray-900">
-                {currentConfig.appName ? `Edit ${currentConfig.appName}` : 'Create New Deployment'}
-              </h3>
-              <button
-                onClick={() => setShowForm(false)}
-                className="text-gray-400 hover:text-gray-600 transition-colors duration-200"
-              >
-                <X className="w-6 h-6" />
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-2xl mx-auto max-h-[90vh] overflow-y-auto flex flex-col">
+            <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+              <h3 className="text-2xl font-bold text-gray-900 dark:text-white">Create Deployment</h3>
+              <button onClick={() => setShowForm(false)} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
               </button>
             </div>
-            
-            {/* Modal Content */}
-            <div className="flex-1 overflow-y-auto p-6">
-              <DeploymentForm 
-                config={currentConfig} 
+            <div className="flex-1 p-6 overflow-y-auto">
+              <DeploymentForm
+                config={currentConfig}
                 onChange={handleConfigChange}
                 availableNamespaces={availableNamespaces}
                 availableConfigMaps={configMaps}
                 availableSecrets={secrets}
               />
             </div>
-            
-            {/* Modal Footer */}
-            <div className="flex items-center justify-end space-x-3 p-6 border-t border-gray-200 bg-gray-50 flex-shrink-0">
+            <div className="flex justify-end space-x-3 p-6 border-t border-gray-200 dark:border-gray-700">
               <button
+                type="button"
                 onClick={() => setShowForm(false)}
-                className="px-6 py-2.5 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-200 font-medium"
+                className="px-6 py-2.5 bg-white border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
               >
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={() => setShowForm(false)}
-                className="px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 font-medium shadow-sm"
+                className="px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium shadow-sm"
               >
                 Save
               </button>
@@ -949,6 +1203,25 @@ function App() {
           onAddSecret={handleAddSecret}
           onDeleteSecret={handleDeleteSecret}
           onClose={() => setShowSecretManager(false)}
+        />
+      )}
+
+      {/* Job Manager Modal */}
+      {showJobManager && (
+        <JobManager
+          jobs={jobs}
+          namespaces={namespaces.map(ns => ns.name)}
+          onAddJob={handleAddJob}
+          onUpdateJob={handleUpdateJob}
+          onDeleteJob={handleDeleteJob}
+          onClose={() => {
+            setShowJobManager(false);
+            setJobToEdit(undefined);
+          }}
+          initialJobType={jobTypeToCreate}
+          initialJob={jobToEdit}
+          availableConfigMaps={configMaps}
+          availableSecrets={secrets}
         />
       )}
     </div>

--- a/src/components/JobForm.tsx
+++ b/src/components/JobForm.tsx
@@ -1,0 +1,565 @@
+import React, { useState } from 'react';
+import { Play } from 'lucide-react';
+import type { Container, EnvVar } from '../types';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+// Helper for tooltips
+const Tooltip = ({ text }: { text: string }) => (
+  <span className="ml-1 text-gray-400 cursor-help" tabIndex={0} aria-label={text} title={text}>
+    <svg className="inline w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M12 16v-4M12 8h.01" /></svg>
+  </span>
+);
+
+export interface JobFormProps {
+  mode: 'job' | 'cronjob';
+  namespaces: string[];
+  onSave: (yaml: string, asTemplate: boolean, state: JobFormState) => void;
+  initialValues?: Partial<JobFormState>;
+  onClose?: () => void;
+  availableConfigMaps: import('../types').ConfigMap[];
+  availableSecrets: import('../types').Secret[];
+}
+
+interface JobFormState {
+  name: string;
+  containers: Container[];
+  namespace: string;
+  labels: { key: string; value: string }[];
+  restartPolicy: 'Never' | 'OnFailure';
+  // Scaling fields
+  replicas: number;
+  completions: number;
+  backoffLimit: number;
+  // CronJob fields
+  schedule: string;
+  concurrencyPolicy: 'Allow' | 'Forbid' | 'Replace';
+  startingDeadline: string;
+  historySuccess: string;
+  historyFailure: string;
+  saveAsTemplate: boolean;
+}
+
+const defaultContainer: Container = {
+  name: '',
+  image: '',
+  env: [],
+  resources: {
+    requests: { cpu: '100m', memory: '128Mi' },
+    limits: { cpu: '', memory: '' }
+  },
+  volumeMounts: []
+};
+
+const defaultState: JobFormState = {
+  name: '',
+  containers: [ { ...defaultContainer } ],
+  namespace: 'default',
+  labels: [],
+  restartPolicy: 'Never',
+  replicas: 1,
+  completions: 1,
+  backoffLimit: 6,
+  schedule: '',
+  concurrencyPolicy: 'Allow',
+  startingDeadline: '',
+  historySuccess: '',
+  historyFailure: '',
+  saveAsTemplate: false,
+};
+
+function validateJob(state: JobFormState, mode: 'job' | 'cronjob') {
+  const errors: { [k: string]: string } = {};
+  if (!state.name) errors.name = 'Job name is required.';
+  else if (!/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(state.name) || state.name.length > 63)
+    errors.name = 'Alphanumeric, dashes, max 63 chars.';
+  if (!state.namespace) errors.namespace = 'Namespace is required.';
+  if (!state.containers.length) errors.containers = 'At least one container is required.';
+  state.containers.forEach((c, i) => {
+    if (!c.image) errors[`container-image-${i}`] = 'Container image is required.';
+    if (!c.name) errors[`container-name-${i}`] = 'Container name is required.';
+    if (!c.resources.requests.cpu) errors[`container-cpu-${i}`] = 'CPU request is required.';
+    if (!c.resources.requests.memory) errors[`container-mem-${i}`] = 'Memory request is required.';
+  });
+  if (mode === 'cronjob') {
+    if (!state.schedule) errors.schedule = 'Schedule is required.';
+    else if (!/^([*\/0-9,-]+\s+){4}[*\/0-9,-]+$/.test(state.schedule)) errors.schedule = 'Invalid cron format.';
+  }
+  return errors;
+}
+
+function generateJobYaml(state: JobFormState, mode: 'job' | 'cronjob') {
+  const meta = `  name: ${state.name}\n  namespace: ${state.namespace}\n  labels:${state.labels.length ? '' : ' {}'}\n` +
+    state.labels.map(l => `    ${l.key}: ${l.value}`).join('\n');
+  const containersYaml = state.containers.map(c =>
+    `      - name: ${c.name || 'container'}\n        image: ${c.image}\n` +
+    (c.command ? `        command: [${c.command.split(' ').map(s => `\"${s}\"`).join(', ')}]\n` : '') +
+    (c.args ? `        args: [${c.args.split(' ').map(s => `\"${s}\"`).join(', ')}]\n` : '') +
+    `        resources:\n          requests:\n            cpu: \"${c.resources.requests.cpu}\"\n            memory: \"${c.resources.requests.memory}\"\n` +
+    (c.resources.limits.cpu || c.resources.limits.memory ? `          limits:\n            cpu: \"${c.resources.limits.cpu || c.resources.requests.cpu}\"\n            memory: \"${c.resources.limits.memory || c.resources.requests.memory}\"\n` : '')
+  ).join('');
+  const jobSpec = `apiVersion: batch/v1\nkind: Job\nmetadata:\n${meta}spec:\n  parallelism: ${state.replicas}\n  completions: ${state.completions}\n  backoffLimit: ${state.backoffLimit}\n  template:\n    spec:\n      restartPolicy: ${state.restartPolicy}\n      containers:\n${containersYaml}`;
+  if (mode === 'job') return jobSpec;
+  return `apiVersion: batch/v1\nkind: CronJob\nmetadata:\n${meta}spec:\n  schedule: \"${state.schedule}\"\n  concurrencyPolicy: ${state.concurrencyPolicy}\n  startingDeadlineSeconds: ${state.startingDeadline || 60}\n  successfulJobsHistoryLimit: ${state.historySuccess || 3}\n  failedJobsHistoryLimit: ${state.historyFailure || 1}\n  jobTemplate:\n    spec:\n      parallelism: ${state.replicas}\n      completions: ${state.completions}\n      backoffLimit: ${state.backoffLimit}\n      template:\n        spec:\n          restartPolicy: ${state.restartPolicy}\n          containers:\n${containersYaml}`;
+}
+
+export const JobForm: React.FC<JobFormProps> = ({ mode, namespaces, onSave, initialValues, onClose, availableConfigMaps, availableSecrets }) => {
+  const [state, setState] = useState<JobFormState>({ ...defaultState, ...initialValues });
+  const [errors, setErrors] = useState<{ [k: string]: string }>({});
+  const [yaml, setYaml] = useState('');
+  const [testScheduleResult, setTestScheduleResult] = useState<string>('');
+  const [copied, setCopied] = useState(false);
+
+  // Filter ConfigMaps and Secrets by selected namespace
+  const filteredConfigMaps = availableConfigMaps.filter(cm => cm.namespace === state.namespace);
+  const filteredSecrets = availableSecrets.filter(s => s.namespace === state.namespace);
+
+  React.useEffect(() => {
+    setYaml(generateJobYaml(state, mode));
+  }, [state, mode]);
+
+  function handleChange<K extends keyof JobFormState>(key: K, value: JobFormState[K]) {
+    setState(s => ({ ...s, [key]: value }));
+  }
+
+  function handleLabelChange(idx: number, key: string, value: string) {
+    setState(s => ({
+      ...s,
+      labels: s.labels.map((l, i) => i === idx ? { key, value } : l)
+    }));
+  }
+
+  function addLabel() {
+    setState(s => ({ ...s, labels: [...s.labels, { key: '', value: '' }] }));
+  }
+
+  function removeLabel(idx: number) {
+    setState(s => ({ ...s, labels: s.labels.filter((_, i) => i !== idx) }));
+  }
+
+  function addContainer() {
+    setState(s => ({ ...s, containers: [...s.containers, { ...defaultContainer }] }));
+  }
+
+  function removeContainer(idx: number) {
+    setState(s => ({ ...s, containers: s.containers.filter((_, i) => i !== idx) }));
+  }
+
+  function duplicateContainer(idx: number) {
+    setState(s => {
+      const containerToDuplicate = s.containers[idx];
+      const duplicated = { ...containerToDuplicate, name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : '' };
+      const newContainers = [...s.containers];
+      newContainers.splice(idx + 1, 0, duplicated);
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function updateContainer(idx: number, updates: Partial<Container>) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[idx] = { ...newContainers[idx], ...updates };
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function addContainerEnvVar(containerIdx: number) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].env.push({ name: '', value: '' });
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function removeContainerEnvVar(containerIdx: number, envIdx: number) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].env = newContainers[containerIdx].env.filter((_, i) => i !== envIdx);
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function updateContainerEnvVar(containerIdx: number, envIdx: number, updates: Partial<EnvVar>) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].env[envIdx] = { ...newContainers[containerIdx].env[envIdx], ...updates };
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function addContainerVolumeMount(containerIdx: number) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].volumeMounts.push({ name: '', mountPath: '' });
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function removeContainerVolumeMount(containerIdx: number, mountIdx: number) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].volumeMounts = newContainers[containerIdx].volumeMounts.filter((_, i) => i !== mountIdx);
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function updateContainerVolumeMount(containerIdx: number, mountIdx: number, field: 'name' | 'mountPath', value: string) {
+    setState(s => {
+      const newContainers = [...s.containers];
+      newContainers[containerIdx].volumeMounts[mountIdx] = { ...newContainers[containerIdx].volumeMounts[mountIdx], [field]: value };
+      return { ...s, containers: newContainers };
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const errs = validateJob(state, mode);
+    setErrors(errs);
+    if (Object.keys(errs).length === 0) {
+      onSave(yaml, false, state);
+    }
+  }
+
+  function handleCopyYaml() {
+    navigator.clipboard.writeText(yaml);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  function handleTestSchedule() {
+    // Simple cron test: show next 3 times (not a real cron parser)
+    if (!/^([*\/0-9,-]+\s+){4}[*\/0-9,-]+$/.test(state.schedule)) {
+      setTestScheduleResult('Invalid cron format.');
+      return;
+    }
+    setTestScheduleResult('Next runs: (demo) 2024-06-12 12:00, 2024-06-12 12:05, 2024-06-12 12:10');
+  }
+
+  function handleDownloadYaml() {
+    const blob = new Blob([yaml], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${state.name || 'k8s-job'}.yaml`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 px-2 sm:px-0">
+      <form className="w-full max-w-lg sm:max-w-2xl mx-auto bg-white dark:bg-gray-900 rounded-2xl shadow-2xl overflow-hidden border border-gray-200 dark:border-gray-800 flex flex-col max-h-[90vh]" autoComplete="off" onSubmit={handleSubmit}>
+        {/* Modal Header */}
+        <div className="sticky top-0 z-10 px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex items-center justify-between">
+          <h2 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white flex items-center">
+            <Play className="w-6 h-6 text-blue-600 mr-2" />
+            {mode === 'cronjob' ? 'Create CronJob' : 'Create Job'}
+          </h2>
+          {onClose && (
+            <button type="button" onClick={onClose} className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+              <span className="sr-only">Close</span>
+            </button>
+          )}
+        </div>
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-6">
+          {/* General Info */}
+          <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4 mb-4">
+            <h3 className="text-base font-semibold mb-3 flex items-center text-gray-900 dark:text-white">
+              <Play className="w-5 h-5 text-blue-600 mr-2" /> General Info
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Job Name <span className="text-red-500 ml-1">*</span> <Tooltip text="Alphanumeric, dashes, max 63 chars. Used as metadata.name." /></label>
+                <input className={`w-full rounded border px-3 py-2 ${errors.name ? 'border-red-500' : 'border-gray-300'}`} value={state.name} maxLength={63} onChange={e => handleChange('name', e.target.value)} required aria-invalid={!!errors.name} />
+                {errors.name && <div className="text-red-500 text-xs mt-1">{errors.name}</div>}
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Namespace <span className="text-red-500 ml-1">*</span> <Tooltip text="Kubernetes namespace to create the Job in." /></label>
+                <select className={`w-full rounded border px-3 py-2 ${errors.namespace ? 'border-red-500' : 'border-gray-300'}`} value={state.namespace} onChange={e => handleChange('namespace', e.target.value)} required>
+                  <option value="">Select namespace</option>
+                  {namespaces.map(ns => <option key={ns} value={ns}>{ns}</option>)}
+                </select>
+                {errors.namespace && <div className="text-red-500 text-xs mt-1">{errors.namespace}</div>}
+              </div>
+              <div className="md:col-span-2">
+                <label className="block text-sm font-medium mb-1 flex items-center">Labels <Tooltip text="Key-value pairs for metadata.labels." /></label>
+                <div className="space-y-2">
+                  {state.labels.map((l, i) => (
+                    <div key={i} className="flex gap-2 items-center">
+                      <input className="w-1/3 rounded border border-gray-300 px-2 py-1" placeholder="key" value={l.key} onChange={e => handleLabelChange(i, e.target.value, l.value)} />
+                      <span>:</span>
+                      <input className="w-1/2 rounded border border-gray-300 px-2 py-1" placeholder="value" value={l.value} onChange={e => handleLabelChange(i, l.key, e.target.value)} />
+                      <button type="button" className="text-red-500 px-2" onClick={() => removeLabel(i)} aria-label="Remove label">×</button>
+                    </div>
+                  ))}
+                  <button type="button" className="text-blue-600 text-xs mt-1" onClick={addLabel}>+ Add Label</button>
+                </div>
+              </div>
+            </div>
+          </section>
+          {/* Containers Section */}
+          <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4 mb-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold flex items-center text-gray-900 dark:text-white">
+                <Play className="w-5 h-5 text-pink-600 mr-2" /> Containers ({state.containers.length})
+              </h3>
+              <button type="button" onClick={addContainer} className="inline-flex items-center px-3 py-1 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors duration-200 text-sm">
+                <span className="mr-1">+</span> Add Container
+              </button>
+            </div>
+            <div className="space-y-6">
+              {state.containers.map((container, idx) => (
+                <div key={idx} className="border border-gray-200 rounded-xl p-6 bg-gray-50">
+                  <div className="flex items-center justify-between mb-4">
+                    <h4 className="text-lg font-medium text-gray-900">Container {idx + 1} {container.name && <span className="ml-2 text-sm text-gray-500">({container.name})</span>}</h4>
+                    <div className="flex items-center space-x-2">
+                      <button type="button" onClick={() => duplicateContainer(idx)} className="p-1 text-gray-400 hover:text-blue-600 rounded transition-colors duration-200" title="Duplicate container">⧉</button>
+                      {state.containers.length > 1 && (
+                        <button type="button" onClick={() => removeContainer(idx)} className="p-1 text-gray-400 hover:text-red-600 rounded transition-colors duration-200" title="Remove container">×</button>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Container Name *</label>
+                      <input type="text" value={container.name} onChange={e => updateContainer(idx, { name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="web-server" />
+                      {errors[`container-name-${idx}`] && <div className="text-red-500 text-xs mt-1">{errors[`container-name-${idx}`]}</div>}
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Container Image *</label>
+                      <input type="text" value={container.image} onChange={e => updateContainer(idx, { image: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="nginx:latest" />
+                      {errors[`container-image-${idx}`] && <div className="text-red-500 text-xs mt-1">{errors[`container-image-${idx}`]}</div>}
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Command</label>
+                      <input type="text" value={container.command || ''} onChange={e => updateContainer(idx, { command: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. sleep" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Arguments</label>
+                      <input type="text" value={container.args || ''} onChange={e => updateContainer(idx, { args: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. 60" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">CPU Request *</label>
+                      <input type="text" value={container.resources.requests.cpu} onChange={e => updateContainer(idx, { resources: { ...container.resources, requests: { ...container.resources.requests, cpu: e.target.value } } })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. 100m" />
+                      {errors[`container-cpu-${idx}`] && <div className="text-red-500 text-xs mt-1">{errors[`container-cpu-${idx}`]}</div>}
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Memory Request *</label>
+                      <input type="text" value={container.resources.requests.memory} onChange={e => updateContainer(idx, { resources: { ...container.resources, requests: { ...container.resources.requests, memory: e.target.value } } })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. 128Mi" />
+                      {errors[`container-mem-${idx}`] && <div className="text-red-500 text-xs mt-1">{errors[`container-mem-${idx}`]}</div>}
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">CPU Limit</label>
+                      <input type="text" value={container.resources.limits.cpu} onChange={e => updateContainer(idx, { resources: { ...container.resources, limits: { ...container.resources.limits, cpu: e.target.value } } })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. 200m" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Memory Limit</label>
+                      <input type="text" value={container.resources.limits.memory} onChange={e => updateContainer(idx, { resources: { ...container.resources, limits: { ...container.resources.limits, memory: e.target.value } } })} className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="e.g. 256Mi" />
+                    </div>
+                  </div>
+                  {/* Environment Variables */}
+                  <div className="mb-6">
+                    <div className="flex items-center justify-between mb-3">
+                      <h5 className="text-sm font-medium text-gray-700">Environment Variables</h5>
+                      <button type="button" onClick={() => addContainerEnvVar(idx)} className="inline-flex items-center px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 transition-colors duration-200">
+                        + Add
+                      </button>
+                    </div>
+                    {container.env.length > 0 && (
+                      <div className="space-y-3">
+                        {container.env.map((envVar, envIdx) => (
+                          <div key={envIdx} className="border border-gray-200 rounded-lg p-3 bg-white">
+                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
+                              <div>
+                                <label className="block text-xs font-medium text-gray-600 mb-1">Variable Name *</label>
+                                <input type="text" value={envVar.name} onChange={e => updateContainerEnvVar(idx, envIdx, { name: e.target.value })} className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="DATABASE_URL" />
+                              </div>
+                              <div>
+                                <label className="block text-xs font-medium text-gray-600 mb-1">Value Source</label>
+                                <select value={envVar.valueFrom ? envVar.valueFrom.type : 'direct'} onChange={e => {
+                                  if (e.target.value === 'direct') {
+                                    updateContainerEnvVar(idx, envIdx, { value: envVar.value || '', valueFrom: undefined });
+                                  } else {
+                                    updateContainerEnvVar(idx, envIdx, { value: undefined, valueFrom: { type: e.target.value as 'configMap' | 'secret', name: '', key: '' } });
+                                  }
+                                }} className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm">
+                                  <option value="direct">Direct Value</option>
+                                  <option value="configMap">ConfigMap</option>
+                                  <option value="secret">Secret</option>
+                                </select>
+                              </div>
+                              {envVar.valueFrom ? (
+                                <>
+                                  <div>
+                                    <label className="block text-xs font-medium text-gray-600 mb-1">{envVar.valueFrom.type === 'configMap' ? 'ConfigMap' : 'Secret'} Name</label>
+                                    <select value={envVar.valueFrom.name} onChange={e => updateContainerEnvVar(idx, envIdx, { valueFrom: { ...envVar.valueFrom!, name: e.target.value } })} className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm">
+                                      <option value="">Select {envVar.valueFrom.type}</option>
+                                      {envVar.valueFrom.type === 'configMap'
+                                        ? filteredConfigMaps.map(cm => (<option key={cm.name} value={cm.name}>{cm.name}</option>))
+                                        : filteredSecrets.map(s => (<option key={s.name} value={s.name}>{s.name}</option>))}
+                                    </select>
+                                  </div>
+                                  <div>
+                                    <label className="block text-xs font-medium text-gray-600 mb-1">Key</label>
+                                    <select value={envVar.valueFrom.key} onChange={e => updateContainerEnvVar(idx, envIdx, { valueFrom: { ...envVar.valueFrom!, key: e.target.value } })} className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm" disabled={!envVar.valueFrom.name}>
+                                      <option value="">Select key</option>
+                                      {envVar.valueFrom.name && (
+                                        envVar.valueFrom.type === 'configMap'
+                                          ? filteredConfigMaps.find(cm => cm.name === envVar.valueFrom!.name)?.data &&
+                                            Object.keys(filteredConfigMaps.find(cm => cm.name === envVar.valueFrom!.name)!.data).map(key => (
+                                              <option key={key} value={key}>{key}</option>
+                                            ))
+                                          : filteredSecrets.find(s => s.name === envVar.valueFrom!.name)?.data &&
+                                            Object.keys(filteredSecrets.find(s => s.name === envVar.valueFrom!.name)!.data).map(key => (
+                                              <option key={key} value={key}>{key}</option>
+                                            ))
+                                      )}
+                                    </select>
+                                  </div>
+                                </>
+                              ) : (
+                                <div className="sm:col-span-2">
+                                  <label className="block text-xs font-medium text-gray-600 mb-1">Value</label>
+                                  <input type="text" value={envVar.value || ''} onChange={e => updateContainerEnvVar(idx, envIdx, { value: e.target.value })} className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm" placeholder="environment value" />
+                                </div>
+                              )}
+                            </div>
+                            <div className="flex justify-end">
+                              <button type="button" onClick={() => removeContainerEnvVar(idx, envIdx)} className="p-1 text-red-600 hover:bg-red-50 rounded transition-colors duration-200">×</button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  {/* Volume Mounts */}
+                  <div>
+                    <div className="flex items-center justify-between mb-3">
+                      <h5 className="text-sm font-medium text-gray-700">Volume Mounts</h5>
+                      <button type="button" onClick={() => addContainerVolumeMount(idx)} className="inline-flex items-center px-2 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700 transition-colors duration-200">
+                        + Add
+                      </button>
+                    </div>
+                    {container.volumeMounts.length > 0 && (
+                      <div className="space-y-2">
+                        {container.volumeMounts.map((mount, mountIdx) => (
+                          <div key={mountIdx} className="flex items-center space-x-2">
+                            <input type="text" value={mount.name} onChange={e => updateContainerVolumeMount(idx, mountIdx, 'name', e.target.value)} className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm" placeholder="Volume name" />
+                            <input type="text" value={mount.mountPath} onChange={e => updateContainerVolumeMount(idx, mountIdx, 'mountPath', e.target.value)} className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm" placeholder="/path/to/mount" />
+                            <button type="button" onClick={() => removeContainerVolumeMount(idx, mountIdx)} className="p-1 text-red-600 hover:bg-red-50 rounded transition-colors duration-200">×</button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+          {/* Job Policy Section */}
+          <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4 mb-4">
+            <h3 className="text-base font-semibold mb-3 flex items-center text-gray-900 dark:text-white">
+              <Play className="w-5 h-5 text-green-600 mr-2" /> Job Policy
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Restart Policy <span className="text-red-500 ml-1">*</span> <Tooltip text="Job restart policy. Usually Never or OnFailure." /></label>
+                <select className="w-full rounded border border-gray-300" value={state.restartPolicy} onChange={e => handleChange('restartPolicy', e.target.value as any)} required>
+                  <option value="Never">Never</option>
+                  <option value="OnFailure">OnFailure</option>
+                </select>
+              </div>
+            </div>
+          </section>
+          {/* Scaling and Upgrade Policy Section */}
+          <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4 mb-4">
+            <h3 className="text-base font-semibold mb-3 flex items-center text-gray-900 dark:text-white">
+              <Play className="w-5 h-5 text-indigo-600 mr-2" /> Scaling and Upgrade Policy
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Replicas <Tooltip text="Number of pods to run in parallel." /></label>
+                <input type="number" min="1" className="w-full rounded border border-gray-300 px-3 py-2" value={state.replicas} onChange={e => handleChange('replicas', Number(e.target.value))} placeholder="e.g. 1" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Completions <Tooltip text="Number of successful completions required." /></label>
+                <input type="number" min="1" className="w-full rounded border border-gray-300 px-3 py-2" value={state.completions} onChange={e => handleChange('completions', Number(e.target.value))} placeholder="e.g. 1" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 flex items-center">Backoff Limit <Tooltip text="Number of retries before marking as failed." /></label>
+                <input type="number" min="0" className="w-full rounded border border-gray-300 px-3 py-2" value={state.backoffLimit} onChange={e => handleChange('backoffLimit', Number(e.target.value))} placeholder="e.g. 6" />
+              </div>
+            </div>
+          </section>
+          {/* CronJob Section */}
+          {mode === 'cronjob' && (
+            <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4 mb-4">
+              <h3 className="text-base font-semibold mb-3 flex items-center text-gray-900 dark:text-white">
+                <Play className="w-5 h-5 text-purple-600 mr-2" /> CronJob Settings
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1 flex items-center">Schedule <span className="text-red-500 ml-1">*</span> <Tooltip text="Cron format, e.g. */5 * * * *." /></label>
+                  <input className={`w-full rounded border px-3 py-2 ${errors.schedule ? 'border-red-500' : 'border-gray-300'}`} value={state.schedule} onChange={e => handleChange('schedule', e.target.value)} placeholder="e.g. */5 * * * *" required aria-invalid={!!errors.schedule} />
+                  {errors.schedule && <div className="text-red-500 text-xs mt-1">{errors.schedule}</div>}
+                  <button type="button" className="mt-2 text-blue-600 text-xs" onClick={handleTestSchedule}>Test Schedule</button>
+                  {testScheduleResult && <div className="text-xs mt-1 text-gray-500">{testScheduleResult}</div>}
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1 flex items-center">Concurrency Policy <Tooltip text="How concurrent jobs are handled." /></label>
+                  <select className="w-full rounded border border-gray-300" value={state.concurrencyPolicy} onChange={e => handleChange('concurrencyPolicy', e.target.value as any)}>
+                    <option value="Allow">Allow</option>
+                    <option value="Forbid">Forbid</option>
+                    <option value="Replace">Replace</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1 flex items-center">Starting Deadline (seconds) <Tooltip text="How long to try to start a job if missed." /></label>
+                  <input className="w-full rounded border border-gray-300 px-3 py-2" value={state.startingDeadline} onChange={e => handleChange('startingDeadline', e.target.value)} placeholder="e.g. 60" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1 flex items-center">History Limits <Tooltip text="How many successful/failed jobs to keep." /></label>
+                  <div className="flex gap-2">
+                    <input className="w-1/2 rounded border border-gray-300 px-2 py-1" value={state.historySuccess} onChange={e => handleChange('historySuccess', e.target.value)} placeholder="Success" />
+                    <input className="w-1/2 rounded border border-gray-300 px-2 py-1" value={state.historyFailure} onChange={e => handleChange('historyFailure', e.target.value)} placeholder="Failure" />
+                  </div>
+                </div>
+              </div>
+            </section>
+          )}
+          {/* YAML Preview, Save, Copy, and Template Actions */}
+          <section className="bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-4">
+            <h3 className="text-base font-semibold mb-3 flex items-center text-gray-900 dark:text-white">
+              <Play className="w-5 h-5 text-yellow-600 mr-2" /> YAML Preview
+            </h3>
+            <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-700 shadow-lg dark:bg-gray-950 dark:border-gray-800">
+              <div className="bg-gray-800 px-4 py-2 border-b border-gray-700 dark:bg-gray-900 dark:border-gray-800 flex items-center justify-between rounded-t-xl">
+                <span className="text-gray-400 text-sm font-mono dark:text-gray-500">{state.name || 'k8s-job'}.yaml</span>
+                <div className="flex gap-2">
+                  <button type="button" className="text-xs text-blue-400 hover:text-blue-200" onClick={handleCopyYaml}>{copied ? 'Copied!' : 'Copy'}</button>
+                  <button type="button" className="text-xs text-green-400 hover:text-green-200" onClick={handleDownloadYaml}>Download</button>
+                </div>
+              </div>
+              <div className="bg-gray-900 dark:bg-gray-950 p-0">
+                <SyntaxHighlighter
+                  language="yaml"
+                  style={vscDarkPlus}
+                  customStyle={{ borderRadius: '0 0 0.75rem 0.75rem', fontSize: 13, margin: 0, background: '#1e293b' }}
+                  showLineNumbers
+                  wrapLongLines
+                >
+                  {yaml}
+                </SyntaxHighlighter>
+              </div>
+            </div>
+            <div className="flex flex-col sm:flex-row justify-end mt-4 gap-2">
+              <button type="submit" className="w-full sm:w-auto px-5 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">Save</button>
+            </div>
+          </section>
+        </div>
+      </form>
+    </div>
+  );
+}; 

--- a/src/components/JobManager.tsx
+++ b/src/components/JobManager.tsx
@@ -1,0 +1,321 @@
+import React, { useState } from 'react';
+import { X, Plus, Trash2, Clock, Play } from 'lucide-react';
+import { JobForm, JobFormProps } from './JobForm';
+import type { ConfigMap, Secret, Container } from '../types';
+
+export interface Job {
+  id: string;
+  name: string;
+  type: 'job' | 'cronjob';
+  namespace: string;
+  containers: Container[];
+  image: string;
+  command?: string;
+  args?: string;
+  schedule?: string;
+  cpuRequest: string;
+  memoryRequest: string;
+  cpuLimit?: string;
+  memoryLimit?: string;
+  restartPolicy: 'Never' | 'OnFailure';
+  labels: { key: string; value: string }[];
+  concurrencyPolicy?: 'Allow' | 'Forbid' | 'Replace';
+  startingDeadline?: string;
+  historySuccess?: string;
+  historyFailure?: string;
+  completions?: number;
+  replicas?: number;
+  backoffLimit?: number;
+  activeDeadlineSeconds?: number;
+}
+
+interface JobManagerProps {
+  jobs: Job[];
+  namespaces: string[];
+  onAddJob: (job: Job) => void;
+  onUpdateJob?: (jobId: string, updatedJob: Job) => void;
+  onDeleteJob: (jobId: string) => void;
+  onClose: () => void;
+  initialJobType?: 'job' | 'cronjob';
+  initialJob?: Job;
+  availableConfigMaps: ConfigMap[];
+  availableSecrets: Secret[];
+}
+
+export function JobManager({ jobs, namespaces, onAddJob, onUpdateJob, onDeleteJob, onClose, initialJobType, initialJob, availableConfigMaps, availableSecrets }: JobManagerProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [currentJob, setCurrentJob] = useState<Job | null>(null);
+  const [jobType, setJobType] = useState<'job' | 'cronjob'>(initialJobType || 'job');
+
+  // Update job type when initialJobType changes
+  React.useEffect(() => {
+    if (initialJobType) {
+      setJobType(initialJobType);
+      // Auto-open form when initial job type is provided
+      setShowForm(true);
+    }
+  }, [initialJobType]);
+
+  // Handle initial job for editing
+  React.useEffect(() => {
+    if (initialJob) {
+      setJobType(initialJob.type);
+      setCurrentJob(initialJob);
+      setShowForm(true);
+    }
+  }, [initialJob]);
+
+  const handleAddJob = () => {
+    setJobType('job');
+    setCurrentJob(null);
+    setShowForm(true);
+  };
+
+  const handleAddCronJob = () => {
+    setJobType('cronjob');
+    setCurrentJob(null);
+    setShowForm(true);
+  };
+
+  const handleEditJob = (job: Job) => {
+    setJobType(job.type);
+    setCurrentJob(job);
+    setShowForm(true);
+  };
+
+  const handleSaveJob = (yaml: string, asTemplate: boolean, formState?: any) => {
+    console.log('JobManager handleSaveJob called with:', { yaml, asTemplate, formState, jobType });
+    // formState should include containers array
+    const containers = formState?.containers || [];
+    // Parse the YAML to extract job data
+    // This is a simplified approach - in a real app you'd use a proper YAML parser
+    const lines = yaml.split('\n');
+    const jobData: Partial<Job> = {
+      name: '',
+      namespace: '',
+      image: '',
+      containers,
+      command: '',
+      args: '',
+      schedule: '',
+      cpuRequest: '',
+      memoryRequest: '',
+      cpuLimit: '',
+      memoryLimit: '',
+      restartPolicy: 'Never',
+      labels: formState?.labels || [], // Use labels from formState
+      concurrencyPolicy: 'Allow',
+      startingDeadline: '',
+      historySuccess: '',
+      historyFailure: '',
+    };
+
+    // Simple YAML parsing for key fields
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line.startsWith('name:')) {
+        jobData.name = line.split('name:')[1].trim();
+      } else if (line.startsWith('namespace:')) {
+        jobData.namespace = line.split('namespace:')[1].trim();
+      } else if (line.startsWith('image:')) {
+        jobData.image = line.split('image:')[1].trim();
+      } else if (line.startsWith('schedule:')) {
+        jobData.schedule = line.split('schedule:')[1].trim().replace(/"/g, '');
+      } else if (line.startsWith('concurrencyPolicy:')) {
+        jobData.concurrencyPolicy = line.split('concurrencyPolicy:')[1].trim() as 'Allow' | 'Forbid' | 'Replace';
+      } else if (line.startsWith('startingDeadlineSeconds:')) {
+        jobData.startingDeadline = line.split('startingDeadlineSeconds:')[1].trim();
+      } else if (line.startsWith('successfulJobsHistoryLimit:')) {
+        jobData.historySuccess = line.split('successfulJobsHistoryLimit:')[1].trim();
+      } else if (line.startsWith('failedJobsHistoryLimit:')) {
+        jobData.historyFailure = line.split('failedJobsHistoryLimit:')[1].trim();
+      } else if (line.startsWith('restartPolicy:')) {
+        jobData.restartPolicy = line.split('restartPolicy:')[1].trim() as 'Never' | 'OnFailure';
+      } else if (line.startsWith('cpu:') && lines[i-1]?.includes('requests:')) {
+        jobData.cpuRequest = line.split('cpu:')[1].trim().replace(/"/g, '');
+      } else if (line.startsWith('memory:') && lines[i-1]?.includes('requests:')) {
+        jobData.memoryRequest = line.split('memory:')[1].trim().replace(/"/g, '');
+      } else if (line.startsWith('cpu:') && lines[i-1]?.includes('limits:')) {
+        jobData.cpuLimit = line.split('cpu:')[1].trim().replace(/"/g, '');
+      } else if (line.startsWith('memory:') && lines[i-1]?.includes('limits:')) {
+        jobData.memoryLimit = line.split('memory:')[1].trim().replace(/"/g, '');
+      }
+    }
+
+    const job: Job = {
+      id: currentJob?.id || `job-${Date.now()}`,
+      name: jobData.name || '',
+      type: jobType,
+      namespace: jobData.namespace || '',
+      containers: jobData.containers || [],
+      image: jobData.image || '',
+      command: jobData.command,
+      args: jobData.args,
+      schedule: jobData.schedule,
+      cpuRequest: jobData.cpuRequest || '',
+      memoryRequest: jobData.memoryRequest || '',
+      cpuLimit: jobData.cpuLimit,
+      memoryLimit: jobData.memoryLimit,
+      restartPolicy: jobData.restartPolicy || 'Never',
+      labels: jobData.labels || [],
+      concurrencyPolicy: jobData.concurrencyPolicy,
+      startingDeadline: jobData.startingDeadline,
+      historySuccess: jobData.historySuccess,
+      historyFailure: jobData.historyFailure,
+    };
+
+    console.log('JobManager creating job:', job);
+
+    // If we're editing an existing job, update it; otherwise add a new one
+    if (currentJob && onUpdateJob) {
+      onUpdateJob(currentJob.id, job);
+    } else {
+      onAddJob(job);
+    }
+    
+    setShowForm(false);
+    setCurrentJob(null);
+    setJobType('job'); // Reset to default
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Modal Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Job Manager
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors duration-200"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Modal Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {!showForm ? (
+            <div className="space-y-6">
+              {/* Add Job Buttons */}
+              <div className="flex gap-3">
+                <button
+                  onClick={handleAddJob}
+                  className="flex items-center gap-2 px-4 py-2 bg-pink-600 text-white rounded-lg hover:bg-pink-700 transition-colors duration-200 font-medium"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add Job
+                </button>
+                <button
+                  onClick={handleAddCronJob}
+                  className="flex items-center gap-2 px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors duration-200 font-medium"
+                >
+                  <Clock className="w-4 h-4" />
+                  Add CronJob
+                </button>
+              </div>
+
+              {/* Jobs List */}
+              <div className="space-y-4">
+                <h4 className="text-lg font-medium text-gray-900 dark:text-white">Jobs ({jobs.filter(j => j.type === 'job').length})</h4>
+                {jobs.filter(j => j.type === 'job').map((job) => (
+                  <div key={job.id} className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <Play className="w-5 h-5 text-pink-500" />
+                        <div>
+                          <h5 className="font-medium text-gray-900 dark:text-white">{job.name}</h5>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            {job.namespace} • {job.image}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleEditJob(job)}
+                          className="px-3 py-1 text-sm bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-200 rounded hover:bg-pink-200 dark:hover:bg-pink-800 transition-colors duration-200"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => onDeleteJob(job.id)}
+                          className="p-2 text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors duration-200"
+                          title="Delete job"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* CronJobs List */}
+              <div className="space-y-4">
+                <h4 className="text-lg font-medium text-gray-900 dark:text-white">CronJobs ({jobs.filter(j => j.type === 'cronjob').length})</h4>
+                {jobs.filter(j => j.type === 'cronjob').map((job) => (
+                  <div key={job.id} className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <Clock className="w-5 h-5 text-yellow-500" />
+                        <div>
+                          <h5 className="font-medium text-gray-900 dark:text-white">{job.name}</h5>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            {job.namespace} • {job.schedule} • {job.image}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleEditJob(job)}
+                          className="px-3 py-1 text-sm bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-200 rounded hover:bg-yellow-200 dark:hover:bg-yellow-800 transition-colors duration-200"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => onDeleteJob(job.id)}
+                          className="p-2 text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors duration-200"
+                          title="Delete cronjob"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-lg font-medium text-gray-900 dark:text-white">
+                  {currentJob ? `Edit ${currentJob.name}` : `Create New ${jobType === 'job' ? 'Job' : 'CronJob'}`}
+                </h4>
+                <button
+                  onClick={() => {
+                    setShowForm(false);
+                    setCurrentJob(null);
+                    setJobType('job'); // Reset to default
+                  }}
+                  className="px-3 py-1 text-sm bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200"
+                >
+                  Cancel
+                </button>
+              </div>
+              <JobForm
+                mode={jobType}
+                namespaces={namespaces}
+                onSave={handleSaveJob as JobFormProps['onSave']}
+                initialValues={currentJob as any}
+                onClose={() => setShowForm(false)}
+                availableConfigMaps={availableConfigMaps}
+                availableSecrets={availableSecrets}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/KubernetesIcons.tsx
+++ b/src/components/KubernetesIcons.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface IconProps {
+  className?: string;
+}
+
+export const K8sDeploymentIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12.001 2L3 7V17L12.001 22L21 17V7L12.001 2ZM12.001 15.5C10.0675 15.5 8.501 13.933 8.501 12C8.501 10.067 10.0675 8.5 12.001 8.5C13.9345 8.5 15.501 10.067 15.501 12C15.501 13.933 13.9345 15.5 12.001 15.5Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sNamespaceIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2L2 7V17L12 22L22 17V7L12 2ZM12 4.19L19.36 7.97L12 11.75L4.64 7.97L12 4.19ZM4 16.02V9.24L11 12.86V20.02L4 16.02ZM13 20.02V12.86L20 9.24V16.02L13 20.02Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sConfigMapIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M20 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V6C22 4.9 21.1 4 20 4ZM9 6H11V10H9V6ZM13 6H15V10H13V6ZM4 18V6H7V12H17V6H20V18H4Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sSecretIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M18 8H17V6C17 3.24 14.76 1 12 1C9.24 1 7 3.24 7 6V8H6C4.9 8 4 8.9 4 10V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V10C20 8.9 19.1 8 18 8ZM9 6C9 4.34 10.34 3 12 3C13.66 3 15 4.34 15 6V8H9V6ZM18 20H6V10H18V20ZM12 17C13.1 17 14 16.1 14 15C14 13.9 13.1 13 12 13C10.9 13 10 13.9 10 15C10 16.1 10.9 17 12 17Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sJobIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M14 2H6C4.9 2 4.01 2.9 4.01 4L4 20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM16 18H8V16H16V18ZM16 14H8V12H16V14ZM13 9V3.5L18.5 9H13Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sCronJobIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2ZM12 20C7.6 20 4 16.4 4 12C4 7.6 7.6 4 12 4C16.4 4 20 7.6 20 12C20 16.4 16.4 20 12 20ZM12.5 7H11V13L16.2 16.2L17 14.9L12.5 12.2V7Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sStorageIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 20H22V16H2V20ZM4 17H6V19H4V17ZM2 4V8H22V4H2ZM6 7H4V5H6V7ZM2 14H22V10H2V14ZM4 11H6V13H4V11Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sDaemonSetIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 3L1 9L12 15L21 10.09V17H23V9L12 3ZM5 13.18V17.18L12 21L19 17.18V13.18L12 17L5 13.18Z" fill="currentColor"/>
+  </svg>
+);
+
+export const K8sPodIcon: React.FC<IconProps> = ({ className = "w-4 h-4" }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2L4 6V18L12 22L20 18V6L12 2ZM12 4.21L17.37 7L12 9.83L6.63 7L12 4.21ZM6 16.89L5 16.35V8.17L11 11.15V19.29L6 16.89ZM13 19.29V11.15L19 8.17V16.35L18 16.89L13 19.29Z" fill="currentColor"/>
+  </svg>
+); 

--- a/src/components/ResourceSummary.tsx
+++ b/src/components/ResourceSummary.tsx
@@ -26,7 +26,7 @@ export function ResourceSummary({ config }: ResourceSummaryProps) {
       config.containers.forEach((container, index) => {
         if (!container.name) issues.push(`Container ${index + 1}: Name is required`);
         if (!container.image) issues.push(`Container ${index + 1}: Image is required`);
-        if (container.port <= 0) issues.push(`Container ${index + 1}: Port must be greater than 0`);
+        if (container.port && container.port <= 0) issues.push(`Container ${index + 1}: Port must be greater than 0`);
       });
     }
     

--- a/src/components/jobs/CronJobList.tsx
+++ b/src/components/jobs/CronJobList.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { Trash2, AlertTriangle, Clock, Settings } from 'lucide-react';
+import type { CronJobConfig } from '../../types';
+
+interface CronJobListProps {
+  cronjobs: CronJobConfig[];
+  onDelete: (index: number) => void;
+  onEdit?: (index: number) => void;
+  onViewYaml?: (index: number) => void;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export const CronJobList: React.FC<CronJobListProps> = ({ cronjobs, onDelete, onEdit, onViewYaml, selectedIndex, onSelect }) => {
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  const handleDeleteClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(index);
+  };
+
+  const handleConfirmDelete = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(index);
+    setDeleteConfirm(null);
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(null);
+  };
+
+  const handleEditClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onEdit) {
+      onEdit(index);
+    }
+  };
+
+  return (
+    <div className="space-y-1 p-4">
+      {cronjobs.length === 0 && (
+        <div className="text-center text-gray-400 py-8">No CronJobs found.</div>
+      )}
+      {cronjobs.map((cronjob, index) => (
+        <div
+          key={`${cronjob.name}-${cronjob.namespace}-${index}`}
+          className={`p-3 rounded-lg border cursor-pointer transition-all duration-200 ${
+            selectedIndex === index
+              ? 'bg-yellow-50 border-yellow-200 ring-1 ring-yellow-200'
+              : 'bg-white border-gray-200 hover:bg-gray-50'
+          }`}
+          onClick={() => onSelect(index)}
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3 min-w-0 flex-1">
+              <Clock className="w-5 h-5 text-yellow-500" />
+              <div className="min-w-0 flex-1">
+                <div className="font-medium text-gray-900 truncate">
+                  {cronjob.name || 'Untitled CronJob'}
+                </div>
+                <div className="text-sm text-gray-500 truncate">
+                  {cronjob.jobTemplate.containers?.[0]?.image || 'No image specified'}
+                </div>
+                <div className="text-xs text-gray-400 mt-1">
+                  {cronjob.namespace} • {cronjob.schedule}
+                </div>
+              </div>
+            </div>
+            {/* Action Buttons */}
+            <div className="flex items-center space-x-1 flex-shrink-0">
+              {deleteConfirm === index ? (
+                <div className="flex items-center space-x-1">
+                  <button
+                    onClick={handleCancelDelete}
+                    className="px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded hover:bg-gray-200 transition-colors duration-200"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={(e) => handleConfirmDelete(index, e)}
+                    className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 transition-colors duration-200 flex items-center space-x-1"
+                  >
+                    <AlertTriangle className="w-3 h-3" />
+                    <span>Delete</span>
+                  </button>
+                </div>
+              ) : (
+                <>
+                  {onEdit && (
+                    <button
+                      onClick={(e) => handleEditClick(index, e)}
+                      className="p-1 text-gray-400 hover:text-gray-600 rounded transition-colors duration-200"
+                      title="Edit cronjob"
+                    >
+                      <Settings className="w-4 h-4" />
+                    </button>
+                  )}
+                  {onViewYaml && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onViewYaml(index);
+                      }}
+                      className="p-1 text-gray-400 hover:text-blue-600 rounded transition-colors duration-200"
+                      title="View YAML"
+                    >
+                      <span className="text-xs">YAML</span>
+                    </button>
+                  )}
+                  <button
+                    onClick={(e) => handleDeleteClick(index, e)}
+                    className="p-1 text-gray-400 hover:text-red-600 rounded transition-colors duration-200"
+                    title="Delete cronjob"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+          {/* Delete confirmation warning */}
+          {deleteConfirm === index && (
+            <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">
+              <div className="flex items-center space-x-1 mb-1">
+                <AlertTriangle className="w-3 h-3" />
+                <span className="font-medium">Are you sure?</span>
+              </div>
+              <div>This action cannot be undone.</div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}; 

--- a/src/components/jobs/JobList.tsx
+++ b/src/components/jobs/JobList.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { Trash2, AlertTriangle, Play, Settings } from 'lucide-react';
+import type { JobConfig } from '../../types';
+
+interface JobListProps {
+  jobs: JobConfig[];
+  onDelete: (index: number) => void;
+  onEdit?: (index: number) => void;
+  onViewYaml?: (index: number) => void;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export const JobList: React.FC<JobListProps> = ({ jobs, onDelete, onEdit, onViewYaml, selectedIndex, onSelect }) => {
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  const handleDeleteClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(index);
+  };
+
+  const handleConfirmDelete = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(index);
+    setDeleteConfirm(null);
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(null);
+  };
+
+  const handleEditClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onEdit) {
+      onEdit(index);
+    }
+  };
+
+  return (
+    <div className="space-y-1 p-4">
+      {jobs.length === 0 && (
+        <div className="text-center text-gray-400 py-8">No Jobs found.</div>
+      )}
+      {jobs.map((job, index) => (
+        <div
+          key={`${job.name}-${job.namespace}-${index}`}
+          className={`p-3 rounded-lg border cursor-pointer transition-all duration-200 ${
+            selectedIndex === index
+              ? 'bg-pink-50 border-pink-200 ring-1 ring-pink-200'
+              : 'bg-white border-gray-200 hover:bg-gray-50'
+          }`}
+          onClick={() => onSelect(index)}
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3 min-w-0 flex-1">
+              <Play className="w-5 h-5 text-pink-500" />
+              <div className="min-w-0 flex-1">
+                <div className="font-medium text-gray-900 truncate">
+                  {job.name || 'Untitled Job'}
+                </div>
+                <div className="text-sm text-gray-500 truncate">
+                  {job.containers?.[0]?.image || 'No image specified'}
+                </div>
+                <div className="text-xs text-gray-400 mt-1">
+                  {job.namespace}
+                </div>
+              </div>
+            </div>
+            {/* Action Buttons */}
+            <div className="flex items-center space-x-1 flex-shrink-0">
+              {deleteConfirm === index ? (
+                <div className="flex items-center space-x-1">
+                  <button
+                    onClick={handleCancelDelete}
+                    className="px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded hover:bg-gray-200 transition-colors duration-200"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={(e) => handleConfirmDelete(index, e)}
+                    className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 transition-colors duration-200 flex items-center space-x-1"
+                  >
+                    <AlertTriangle className="w-3 h-3" />
+                    <span>Delete</span>
+                  </button>
+                </div>
+              ) : (
+                <>
+                  {onEdit && (
+                    <button
+                      onClick={(e) => handleEditClick(index, e)}
+                      className="p-1 text-gray-400 hover:text-gray-600 rounded transition-colors duration-200"
+                      title="Edit job"
+                    >
+                      <Settings className="w-4 h-4" />
+                    </button>
+                  )}
+                  {onViewYaml && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onViewYaml(index);
+                      }}
+                      className="p-1 text-gray-400 hover:text-blue-600 rounded transition-colors duration-200"
+                      title="View YAML"
+                    >
+                      <span className="text-xs">YAML</span>
+                    </button>
+                  )}
+                  <button
+                    onClick={(e) => handleDeleteClick(index, e)}
+                    className="p-1 text-gray-400 hover:text-red-600 rounded transition-colors duration-200"
+                    title="Delete job"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+          {/* Delete confirmation warning */}
+          {deleteConfirm === index && (
+            <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">
+              <div className="flex items-center space-x-1 mb-1">
+                <AlertTriangle className="w-3 h-3" />
+                <span className="font-medium">Are you sure?</span>
+              </div>
+              <div>This action cannot be undone.</div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}; 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,13 +11,15 @@ export interface EnvVar {
 export interface Container {
   name: string;
   image: string;
-  port: number;
+  port?: number;
   env: EnvVar[];
   resources: {
     requests: { cpu: string; memory: string };
     limits: { cpu: string; memory: string };
   };
   volumeMounts: Array<{ name: string; mountPath: string }>;
+  command?: string;
+  args?: string;
 }
 
 export interface IngressRule {
@@ -110,4 +112,32 @@ export interface KubernetesResource {
   spec?: any;
   data?: Record<string, string>;
   type?: string;
+}
+
+export interface JobConfig {
+  name: string;
+  namespace: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  containers: Container[];
+  restartPolicy: 'Never' | 'OnFailure';
+  completions?: number;
+  parallelism?: number;
+  backoffLimit?: number;
+  activeDeadlineSeconds?: number;
+  createdAt?: string;
+}
+
+export interface CronJobConfig {
+  name: string;
+  namespace: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  schedule: string;
+  concurrencyPolicy?: 'Allow' | 'Forbid' | 'Replace';
+  startingDeadlineSeconds?: number;
+  successfulJobsHistoryLimit?: number;
+  failedJobsHistoryLimit?: number;
+  jobTemplate: JobConfig;
+  createdAt?: string;
 }

--- a/src/utils/jobsApi.ts
+++ b/src/utils/jobsApi.ts
@@ -1,0 +1,55 @@
+// Kubernetes Jobs and CronJobs API abstraction
+import type { JobConfig, CronJobConfig } from '../types';
+
+// Placeholder API functions for Jobs and CronJobs
+// These would be replaced with actual Kubernetes API calls
+
+export async function listJobs(_namespace: string): Promise<JobConfig[]> {
+  // Placeholder: Replace with real fetch
+  // const res = await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/jobs`);
+  // const data = await res.json();
+  // return data.items.map(mapJobFromK8s);
+  return [];
+}
+
+export async function listCronJobs(_namespace: string): Promise<CronJobConfig[]> {
+  // Placeholder: Replace with real fetch
+  // const res = await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/cronjobs`);
+  // const data = await res.json();
+  // return data.items.map(mapCronJobFromK8s);
+  return [];
+}
+
+export async function createJob(_namespace: string, _job: JobConfig): Promise<void> {
+  // Placeholder: Replace with real fetch
+  // await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/jobs`, {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify(mapJobToK8s(_job)),
+  // });
+  console.log('Creating job:', _job);
+}
+
+export async function createCronJob(_namespace: string, _cronjob: CronJobConfig): Promise<void> {
+  // Placeholder: Replace with real fetch
+  // await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/cronjobs`, {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify(mapCronJobToK8s(_cronjob)),
+  // });
+  console.log('Creating cronjob:', _cronjob);
+}
+
+export async function deleteJob(_namespace: string, _name: string): Promise<void> {
+  // Placeholder: Replace with real fetch
+  // await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/jobs/${_name}`, { method: 'DELETE' });
+  console.log('Deleting job:', _name);
+}
+
+export async function deleteCronJob(_namespace: string, _name: string): Promise<void> {
+  // Placeholder: Replace with real fetch
+  // await fetch(`${KUBE_API_BASE}/namespaces/${_namespace}/cronjobs/${_name}`, { method: 'DELETE' });
+  console.log('Deleting cronjob:', _name);
+}
+
+// Optionally, add mapping helpers for K8s <-> UI types here 

--- a/src/utils/yamlGenerator.ts
+++ b/src/utils/yamlGenerator.ts
@@ -574,6 +574,12 @@ data:
         allResources.push(`# Ingress Resources: ${ingressCount}`);
       }
     }
+    if (jobs.length > 0) {
+      allResources.push(`# Jobs: ${jobs.length}`);
+    }
+    if (cronjobs.length > 0) {
+      allResources.push(`# CronJobs: ${cronjobs.length}`);
+    }
     allResources.push('');
   }
 

--- a/src/utils/yamlGenerator.ts
+++ b/src/utils/yamlGenerator.ts
@@ -1,4 +1,4 @@
-import type { DeploymentConfig, KubernetesResource, Namespace, ConfigMap, Secret, ProjectSettings } from '../types';
+import type { DeploymentConfig, KubernetesResource, Namespace, ConfigMap, Secret, ProjectSettings, JobConfig, CronJobConfig } from '../types';
 
 export function generateKubernetesYaml(config: DeploymentConfig, projectSettings?: ProjectSettings): string {
   if (!config.appName) {
@@ -480,9 +480,18 @@ export function generateMultiDeploymentYaml(
   namespaces: Namespace[] = [], 
   configMaps: ConfigMap[] = [], 
   secrets: Secret[] = [],
-  projectSettings?: ProjectSettings
+  projectSettings?: ProjectSettings,
+  jobs: JobConfig[] = [],
+  cronjobs: CronJobConfig[] = []
 ): string {
-  if (deployments.length === 0 && namespaces.length <= 1 && configMaps.length === 0 && secrets.length === 0) {
+  if (
+    deployments.length === 0 &&
+    jobs.length === 0 &&
+    cronjobs.length === 0 &&
+    namespaces.length <= 1 &&
+    configMaps.length === 0 &&
+    secrets.length === 0
+  ) {
     return `# Welcome to Kube Composer!
 # 
 # This is a free Kubernetes YAML generator that helps you create
@@ -717,6 +726,105 @@ data:
         allResources.push(deploymentYaml);
       });
     }
+  }
+
+  // === JOBS ===
+  if (jobs.length > 0) {
+    if (customNamespaces.length > 0 || configMaps.length > 0 || secrets.length > 0 || deployments.length > 0) {
+      allResources.push('---');
+      allResources.push('');
+    }
+    allResources.push('# === JOBS ===');
+    jobs.forEach((job, index) => {
+      if (index > 0) {
+        allResources.push('---');
+        allResources.push('');
+      }
+      
+      // Merge global labels with job labels
+      const mergedLabels = projectSettings ? {
+        ...projectSettings.globalLabels,
+        ...job.labels,
+        project: projectSettings.name
+      } : job.labels;
+      
+      allResources.push(objectToYaml({
+        apiVersion: 'batch/v1',
+        kind: 'Job',
+        metadata: {
+          name: job.name,
+          namespace: job.namespace,
+          ...(Object.keys(mergedLabels).length > 0 && { labels: mergedLabels }),
+          ...(Object.keys(job.annotations).length > 0 && { annotations: job.annotations })
+        },
+        spec: {
+          completions: job.completions,
+          parallelism: job.parallelism,
+          backoffLimit: job.backoffLimit,
+          activeDeadlineSeconds: job.activeDeadlineSeconds,
+          template: {
+            spec: {
+              restartPolicy: job.restartPolicy,
+              containers: job.containers
+            }
+          }
+        }
+      }));
+    });
+  }
+
+  // === CRONJOBS ===
+  if (cronjobs.length > 0) {
+    if (customNamespaces.length > 0 || configMaps.length > 0 || secrets.length > 0 || deployments.length > 0 || jobs.length > 0) {
+      allResources.push('---');
+      allResources.push('');
+    }
+    allResources.push('# === CRONJOBS ===');
+    cronjobs.forEach((cronjob, index) => {
+      if (index > 0) {
+        allResources.push('---');
+        allResources.push('');
+      }
+      
+      // Merge global labels with cronjob labels
+      const mergedLabels = projectSettings ? {
+        ...projectSettings.globalLabels,
+        ...cronjob.labels,
+        project: projectSettings.name
+      } : cronjob.labels;
+      
+      allResources.push(objectToYaml({
+        apiVersion: 'batch/v1',
+        kind: 'CronJob',
+        metadata: {
+          name: cronjob.name,
+          namespace: cronjob.namespace,
+          ...(Object.keys(mergedLabels).length > 0 && { labels: mergedLabels }),
+          ...(Object.keys(cronjob.annotations).length > 0 && { annotations: cronjob.annotations })
+        },
+        spec: {
+          schedule: cronjob.schedule,
+          concurrencyPolicy: cronjob.concurrencyPolicy,
+          startingDeadlineSeconds: cronjob.startingDeadlineSeconds,
+          successfulJobsHistoryLimit: cronjob.successfulJobsHistoryLimit,
+          failedJobsHistoryLimit: cronjob.failedJobsHistoryLimit,
+          jobTemplate: {
+            spec: {
+              completions: cronjob.jobTemplate.completions,
+              parallelism: cronjob.jobTemplate.parallelism,
+              backoffLimit: cronjob.jobTemplate.backoffLimit,
+              activeDeadlineSeconds: cronjob.jobTemplate.activeDeadlineSeconds,
+              template: {
+                spec: {
+                  restartPolicy: cronjob.jobTemplate.restartPolicy,
+                  containers: cronjob.jobTemplate.containers
+                }
+              }
+            }
+          }
+        }
+      }));
+    });
   }
 
   return allResources.join('\n');


### PR DESCRIPTION
# Add Kubernetes Jobs and CronJobs Support

## Overview
This PR adds full support for Kubernetes Jobs and CronJobs management with a user-friendly interface matching the existing Deployments functionality. Users can now create, edit, and manage both one-time Jobs and scheduled CronJobs through the UI.

## Features Added
- **Jobs Management**
  - Create and edit Kubernetes Jobs with multiple container support
  - Configure resource requests/limits (CPU/Memory)
  - Set job completion criteria (parallelism, completions, backoffLimit)
  - Support for environment variables from ConfigMaps and Secrets
  - Volume mounts configuration
  - Job-specific restart policies

- **CronJobs Support**
  - Schedule jobs using standard cron syntax
  - Configure concurrency policies (Allow/Forbid/Replace)
  - Set history limits for successful/failed jobs
  - Configure starting deadlines
  - All Job features available for CronJob templates

- **UI/UX Improvements**
  - Dedicated Jobs section in sidebar with separate tabs for Jobs and CronJobs
  - Real-time YAML preview with proper formatting
  - Form validation for all fields
  - Resource summary integration
  - Consistent styling with existing components
