### PR TITLE
Adding k8s Daemondsets support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1110,7 +1110,6 @@ function App() {
                       setSelectedDaemonSet(index);
                       setSidebarOpen(false);
                     }}
-                    onAddDaemonSet={handleAddDaemonSet}
                     onEditDaemonSet={() => setShowForm(true)}
                     onDuplicateDaemonSet={handleDuplicateDaemonSet}
                     onDeleteDaemonSet={handleDeleteDaemonSet}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { Download, FileText, List, Plus, Menu, X, Database, Settings, Key, PlayCircle, Container as Docker, FolderOpen, GitBranch, Clock } from 'lucide-react';
 import { DeploymentForm } from './components/DeploymentForm';
+import { DaemonSetForm } from './components/DaemonSetForm';
 import { YamlPreview } from './components/YamlPreview';
 import { ResourceSummary } from './components/ResourceSummary';
 import { DeploymentsList } from './components/DeploymentsList';
+import { DaemonSetsList } from './components/DaemonSetsList';
 import { NamespacesList } from './components/NamespacesList';
 import { ConfigMapsList } from './components/ConfigMapsList';
 import { SecretsList } from './components/SecretsList';
@@ -21,7 +23,7 @@ import { generateMultiDeploymentYaml } from './utils/yamlGenerator';
 import { JobManager, Job } from './components/JobManager';
 import { JobList } from './components/jobs/JobList';
 import { CronJobList } from './components/jobs/CronJobList';
-import type { DeploymentConfig, Namespace, ConfigMap, Secret, ProjectSettings, JobConfig, CronJobConfig } from './types';
+import type { DeploymentConfig, DaemonSetConfig, Namespace, ConfigMap, Secret, ProjectSettings, JobConfig, CronJobConfig } from './types';
 import {
   K8sDeploymentIcon,
   K8sNamespaceIcon,
@@ -35,7 +37,7 @@ import {
 } from './components/KubernetesIcons';
 
 type PreviewMode = 'visual' | 'yaml' | 'summary' | 'argocd' | 'flow';
-type SidebarTab = 'deployments' | 'namespaces' | 'storage' | 'jobs' | 'configmaps' | 'secrets';
+type SidebarTab = 'deployments' | 'daemonsets' | 'namespaces' | 'storage' | 'jobs' | 'configmaps' | 'secrets';
 
 function App() {
   const [projectSettings, setProjectSettings] = useState<ProjectSettings>({
@@ -46,6 +48,7 @@ function App() {
     updatedAt: new Date().toISOString()
   });
   const [deployments, setDeployments] = useState<DeploymentConfig[]>([]);
+  const [daemonSets, setDaemonSets] = useState<DaemonSetConfig[]>([]);
   const [namespaces, setNamespaces] = useState<Namespace[]>([
     {
       name: 'default',
@@ -58,6 +61,7 @@ function App() {
   const [secrets, setSecrets] = useState<Secret[]>([]);
   const [jobs, setJobs] = useState<Job[]>([]);
   const [selectedDeployment, setSelectedDeployment] = useState<number>(0);
+  const [selectedDaemonSet, setSelectedDaemonSet] = useState<number>(0);
   const [selectedNamespace, setSelectedNamespace] = useState<number>(0);
   const [selectedConfigMap, setSelectedConfigMap] = useState<number>(0);
   const [selectedSecret, setSelectedSecret] = useState<number>(0);
@@ -113,6 +117,34 @@ function App() {
       tls: [],
       rules: []
     }
+  };
+
+  const currentDaemonSetConfig = daemonSets[selectedDaemonSet] || {
+    appName: '',
+    containers: [{
+      name: '',
+      image: '',
+      port: 8080,
+      env: [],
+      resources: {
+        requests: { cpu: '', memory: '' },
+        limits: { cpu: '', memory: '' }
+      },
+      volumeMounts: []
+    }],
+    serviceEnabled: false,
+    port: 80,
+    targetPort: 8080,
+    serviceType: 'ClusterIP',
+    namespace: 'default',
+    labels: {},
+    annotations: {},
+    volumes: [],
+    configMaps: [],
+    secrets: [],
+    selectedConfigMaps: [],
+    selectedSecrets: [],
+    nodeSelector: {}
   };
 
   // Get available namespaces from all deployments
@@ -529,19 +561,21 @@ function App() {
   // Generate YAML for preview based on mode
   const getPreviewYaml = () => {
     const validDeployments = deployments.filter(d => d.appName);
+    const validDaemonSets = daemonSets.filter(d => d.appName);
     // Fix: Only map regular jobs to jobConfigs, not cronjobs
     const jobConfigs = jobs.filter(j => j.type === 'job').map(jobToJobConfig);
     const cronJobConfigs = jobs.filter(j => j.type === 'cronjob').map(jobToCronJobConfig);
-    const yaml = generateMultiDeploymentYaml(validDeployments, namespaces, configMaps, secrets, projectSettings, jobConfigs, cronJobConfigs);
+    const yaml = generateMultiDeploymentYaml(validDeployments, namespaces, configMaps, secrets, projectSettings, jobConfigs, cronJobConfigs, validDaemonSets);
     if (
       validDeployments.length === 0 &&
+      validDaemonSets.length === 0 &&
       jobConfigs.length === 0 &&
       cronJobConfigs.length === 0 &&
       namespaces.length <= 1 &&
       configMaps.length === 0 &&
       secrets.length === 0
     ) {
-      return '# No deployments or jobs configured\n# Create your first deployment or job to see the generated YAML';
+      return '# No deployments, daemonsets, or jobs configured\n# Create your first deployment, daemonset, or job to see the generated YAML';
     }
     return yaml;
   };
@@ -553,7 +587,7 @@ function App() {
   ];
 
   // Check if download should be enabled
-  const hasValidDeployments = deployments.some(d => d.appName);
+  const hasValidDeployments = deployments.some(d => d.appName) || daemonSets.some(d => d.appName);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -611,7 +645,7 @@ function App() {
     setSidebarTab(tab);
     
     // Set preview mode based on the selected tab
-    if (tab === 'deployments') {
+    if (tab === 'deployments' || tab === 'daemonsets') {
       setPreviewMode('flow');
     } else {
       setPreviewMode('yaml');
@@ -627,6 +661,93 @@ function App() {
     } else if (subTab === 'cronjobs') {
       setJobsSubTab('cronjobs');
     }
+  };
+
+  // DaemonSet management
+  const handleDaemonSetConfigChange = (newConfig: DaemonSetConfig) => {
+    // Apply global labels to the new config
+    const configWithGlobalLabels = {
+      ...newConfig,
+      labels: cleanAndMergeLabels(newConfig.labels)
+    };
+
+    const newDaemonSets = [...daemonSets];
+    if (selectedDaemonSet < daemonSets.length) {
+      newDaemonSets[selectedDaemonSet] = configWithGlobalLabels;
+    } else {
+      newDaemonSets.push(configWithGlobalLabels);
+    }
+    setDaemonSets(newDaemonSets);
+  };
+
+  const handleAddDaemonSet = () => {
+    const newDaemonSet: DaemonSetConfig = {
+      appName: '',
+      containers: [{
+        name: '',
+        image: '',
+        port: 8080,
+        env: [],
+        resources: {
+          requests: { cpu: '', memory: '' },
+          limits: { cpu: '', memory: '' }
+        },
+        volumeMounts: []
+      }],
+      serviceEnabled: false,
+      port: 80,
+      targetPort: 8080,
+      serviceType: 'ClusterIP',
+      namespace: 'default',
+      labels: cleanAndMergeLabels({}),
+      annotations: {},
+      volumes: [],
+      configMaps: [],
+      secrets: [],
+      selectedConfigMaps: [],
+      selectedSecrets: [],
+      nodeSelector: {}
+    };
+    setDaemonSets([...daemonSets, newDaemonSet]);
+    setSelectedDaemonSet(daemonSets.length);
+    setSidebarTab('daemonsets');
+    setShowForm(true);
+  };
+
+  const handleDeleteDaemonSet = (index: number) => {
+    if (daemonSets.length <= 1) {
+      // If it's the last daemonset, remove it completely
+      setDaemonSets([]);
+      setSelectedDaemonSet(0);
+      return;
+    }
+
+    const newDaemonSets = daemonSets.filter((_, i) => i !== index);
+    setDaemonSets(newDaemonSets);
+    
+    // Adjust selected daemonset index
+    if (selectedDaemonSet >= index) {
+      setSelectedDaemonSet(Math.max(0, selectedDaemonSet - 1));
+    }
+  };
+
+  const handleDuplicateDaemonSet = (index: number) => {
+    const daemonSetToDuplicate = daemonSets[index];
+    const duplicatedDaemonSet: DaemonSetConfig = {
+      ...daemonSetToDuplicate,
+      appName: `${daemonSetToDuplicate.appName}-copy`,
+      containers: daemonSetToDuplicate.containers.map(container => ({
+        ...container,
+        name: container.name ? `${container.name}-copy` : ''
+      })),
+      labels: cleanAndMergeLabels(daemonSetToDuplicate.labels),
+      nodeSelector: { ...daemonSetToDuplicate.nodeSelector }
+    };
+    
+    const newDaemonSets = [...daemonSets];
+    newDaemonSets.splice(index + 1, 0, duplicatedDaemonSet);
+    setDaemonSets(newDaemonSets);
+    setSelectedDaemonSet(index + 1);
   };
 
   return (
@@ -798,6 +919,20 @@ function App() {
                 </button>
 
                 <button
+                  onClick={() => handleMenuClick('daemonsets')}
+                  className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                    sidebarTab === 'daemonsets' 
+                      ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300 shadow-sm border border-indigo-100 dark:border-indigo-800' 
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/10 hover:text-indigo-600 dark:hover:text-indigo-300'
+                  }`}
+                >
+                  <K8sDaemonSetIcon className={`mr-3 flex-shrink-0 h-6 w-6 ${
+                    sidebarTab === 'daemonsets' ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-500 dark:text-gray-400'
+                  }`} />
+                  DaemonSets
+                </button>
+
+                <button
                   onClick={() => handleMenuClick('namespaces')}
                   className={`flex items-center w-full px-2 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
                     sidebarTab === 'namespaces' 
@@ -809,14 +944,6 @@ function App() {
                     sidebarTab === 'namespaces' ? 'text-purple-600 dark:text-purple-400' : 'text-gray-500 dark:text-gray-400'
                   }`} />
                   Namespaces
-                </button>
-
-                <button
-                  disabled
-                  className="flex items-center w-full px-2 py-2 text-sm font-medium rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                >
-                  <K8sDaemonSetIcon className="mr-3 flex-shrink-0 h-6 w-6 text-gray-400 dark:text-gray-600" />
-                  DaemonSets
                 </button>
 
                 <button
@@ -958,6 +1085,44 @@ function App() {
                     <h3 className="text-lg font-medium text-gray-900 mb-2">No Deployments</h3>
                     <p className="text-sm text-gray-500 mb-4">
                       Get started by creating your first Kubernetes deployment
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {sidebarTab === 'daemonsets' && (
+              <div>
+                <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+                  <button
+                    onClick={handleAddDaemonSet}
+                    className="w-full inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors duration-200 text-sm font-medium"
+                  >
+                    <Plus className="w-4 h-4 mr-2" />
+                    Add DaemonSet
+                  </button>
+                </div>
+                {daemonSets.length > 0 ? (
+                  <DaemonSetsList
+                    daemonSets={daemonSets}
+                    selectedDaemonSet={selectedDaemonSet}
+                    onSelectDaemonSet={(index) => {
+                      setSelectedDaemonSet(index);
+                      setSidebarOpen(false);
+                    }}
+                    onAddDaemonSet={handleAddDaemonSet}
+                    onEditDaemonSet={() => setShowForm(true)}
+                    onDuplicateDaemonSet={handleDuplicateDaemonSet}
+                    onDeleteDaemonSet={handleDeleteDaemonSet}
+                  />
+                ) : (
+                  <div className="p-6 text-center">
+                    <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                      <FileText className="w-8 h-8 text-gray-400" />
+                    </div>
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">No DaemonSets</h3>
+                    <p className="text-sm text-gray-500 mb-4">
+                      Get started by creating your first Kubernetes DaemonSet
                     </p>
                   </div>
                 )}
@@ -1130,6 +1295,11 @@ function App() {
                       <span className="text-gray-500">deployment{deployments.length !== 1 ? 's' : ''}</span>
                     </div>
                     <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
+                      <K8sDaemonSetIcon className="w-5 h-5 text-indigo-500" />
+                      <span className="font-bold">{daemonSets.length}</span>
+                      <span className="text-gray-500">daemonset{daemonSets.length !== 1 ? 's' : ''}</span>
+                    </div>
+                    <div className="flex items-center space-x-1 text-sm text-gray-700 font-medium">
                       <Database className="w-5 h-5 text-purple-500" />
                       <span className="font-bold">{namespaces.length}</span>
                       <span className="text-gray-500">namespace{namespaces.length !== 1 ? 's' : ''}</span>
@@ -1180,7 +1350,7 @@ function App() {
               </div>
             </div>
             <div className="p-4 sm:p-6 pb-8">
-              {previewMode === 'flow' && <VisualPreview deployments={deployments} namespaces={namespaces} configMaps={configMaps} secrets={secrets} containerRef={containerRef} />}
+              {previewMode === 'flow' && <VisualPreview deployments={deployments} daemonSets={daemonSets} namespaces={namespaces} configMaps={configMaps} secrets={secrets} containerRef={containerRef} />}
               {previewMode === 'summary' && <ResourceSummary config={currentConfig} />}
               {previewMode === 'yaml' && <YamlPreview yaml={getPreviewYaml()} />}
             </div>
@@ -1213,24 +1383,36 @@ function App() {
         />
       )}
 
-      {/* Deployment Form Modal */}
+      {/* Deployment/DaemonSet Form Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-2xl mx-auto max-h-[90vh] overflow-y-auto flex flex-col">
             <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-2xl font-bold text-gray-900 dark:text-white">Create Deployment</h3>
+              <h3 className="text-2xl font-bold text-gray-900 dark:text-white">
+                {sidebarTab === 'daemonsets' ? 'Create DaemonSet' : 'Create Deployment'}
+              </h3>
               <button onClick={() => setShowForm(false)} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
                 <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
               </button>
             </div>
             <div className="flex-1 p-6 overflow-y-auto">
-              <DeploymentForm
-                config={currentConfig}
-                onChange={handleConfigChange}
-                availableNamespaces={availableNamespaces}
-                availableConfigMaps={configMaps}
-                availableSecrets={secrets}
-              />
+              {sidebarTab === 'daemonsets' ? (
+                <DaemonSetForm
+                  config={currentDaemonSetConfig}
+                  onChange={handleDaemonSetConfigChange}
+                  availableNamespaces={availableNamespaces}
+                  availableConfigMaps={configMaps}
+                  availableSecrets={secrets}
+                />
+              ) : (
+                <DeploymentForm
+                  config={currentConfig}
+                  onChange={handleConfigChange}
+                  availableNamespaces={availableNamespaces}
+                  availableConfigMaps={configMaps}
+                  availableSecrets={secrets}
+                />
+              )}
             </div>
             <div className="flex justify-end space-x-3 p-6 border-t border-gray-200 dark:border-gray-700">
               <button

--- a/src/components/DaemonSetForm.tsx
+++ b/src/components/DaemonSetForm.tsx
@@ -1,4 +1,4 @@
-import { Plus, Minus, Server, Settings, Database, Key, Trash2, Copy, Globe, FileText } from 'lucide-react';
+import { Plus, Minus, Server, Key, Trash2, Copy, Globe, FileText, Database } from 'lucide-react';
 import type { DaemonSetConfig, Container, ConfigMap, Secret, EnvVar } from '../types';
 import React, { useState, useEffect, useRef } from 'react';
 

--- a/src/components/DaemonSetForm.tsx
+++ b/src/components/DaemonSetForm.tsx
@@ -1,0 +1,910 @@
+import { Plus, Minus, Server, Settings, Database, Key, Trash2, Copy, Globe, FileText } from 'lucide-react';
+import type { DaemonSetConfig, Container, ConfigMap, Secret, EnvVar } from '../types';
+import React, { useState, useEffect, useRef } from 'react';
+
+interface DaemonSetFormProps {
+  config: DaemonSetConfig;
+  onChange: (config: DaemonSetConfig) => void;
+  availableNamespaces: string[];
+  availableConfigMaps: ConfigMap[];
+  availableSecrets: Secret[];
+}
+
+export function DaemonSetForm({ config, onChange, availableNamespaces, availableConfigMaps, availableSecrets }: DaemonSetFormProps) {
+  const updateConfig = (updates: Partial<DaemonSetConfig>) => {
+    onChange({ ...config, ...updates });
+  };
+
+  // Node Selector local state for editing
+  const [nodeSelectorPairs, setNodeSelectorPairs] = useState<{ key: string; value: string }[]>([]);
+  const isLocalNodeSelectorEdit = useRef(false);
+
+  useEffect(() => {
+    if (!isLocalNodeSelectorEdit.current) {
+      setNodeSelectorPairs(
+        config.nodeSelector && Object.keys(config.nodeSelector).length > 0
+          ? Object.entries(config.nodeSelector).map(([key, value]) => ({ key, value }))
+          : []
+      );
+    }
+    isLocalNodeSelectorEdit.current = false;
+  }, [config.nodeSelector]);
+
+  // Helper to sync local state to config
+  const syncNodeSelectorToConfig = (pairs: { key: string; value: string }[]) => {
+    isLocalNodeSelectorEdit.current = true;
+    const obj: Record<string, string> = {};
+    pairs.forEach(({ key, value }) => {
+      if (key.trim() !== '') obj[key] = value;
+    });
+    updateConfig({ nodeSelector: obj });
+  };
+
+  // Filter ConfigMaps and Secrets by namespace
+  const filteredConfigMaps = availableConfigMaps.filter(cm => cm.namespace === config.namespace);
+  const filteredSecrets = availableSecrets.filter(s => s.namespace === config.namespace);
+
+  // Container management functions
+  const addContainer = () => {
+    const newContainer: Container = {
+      name: '',
+      image: '',
+      port: 8080,
+      env: [],
+      resources: {
+        requests: { cpu: '', memory: '' },
+        limits: { cpu: '', memory: '' }
+      },
+      volumeMounts: []
+    };
+    updateConfig({
+      containers: [...config.containers, newContainer]
+    });
+  };
+
+  const removeContainer = (index: number) => {
+    if (config.containers.length > 1) {
+      updateConfig({
+        containers: config.containers.filter((_, i) => i !== index)
+      });
+    }
+  };
+
+  const duplicateContainer = (index: number) => {
+    const containerToDuplicate = config.containers[index];
+    const duplicatedContainer: Container = {
+      ...containerToDuplicate,
+      name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : ''
+    };
+    
+    const newContainers = [...config.containers];
+    newContainers.splice(index + 1, 0, duplicatedContainer);
+    updateConfig({ containers: newContainers });
+  };
+
+  const updateContainer = (index: number, updates: Partial<Container>) => {
+    const newContainers = [...config.containers];
+    newContainers[index] = { ...newContainers[index], ...updates };
+    updateConfig({ containers: newContainers });
+  };
+
+  const addContainerEnvVar = (containerIndex: number) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].env.push({ name: '', value: '' });
+    updateConfig({ containers: newContainers });
+  };
+
+  const removeContainerEnvVar = (containerIndex: number, envIndex: number) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].env = newContainers[containerIndex].env.filter((_, i) => i !== envIndex);
+    updateConfig({ containers: newContainers });
+  };
+
+  const updateContainerEnvVar = (containerIndex: number, envIndex: number, updates: Partial<EnvVar>) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].env[envIndex] = {
+      ...newContainers[containerIndex].env[envIndex],
+      ...updates
+    };
+    updateConfig({ containers: newContainers });
+  };
+
+  const addContainerVolumeMount = (containerIndex: number) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].volumeMounts.push({ name: '', mountPath: '' });
+    updateConfig({ containers: newContainers });
+  };
+
+  const removeContainerVolumeMount = (containerIndex: number, mountIndex: number) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].volumeMounts = newContainers[containerIndex].volumeMounts.filter((_, i) => i !== mountIndex);
+    updateConfig({ containers: newContainers });
+  };
+
+  const updateContainerVolumeMount = (containerIndex: number, mountIndex: number, field: 'name' | 'mountPath', value: string) => {
+    const newContainers = [...config.containers];
+    newContainers[containerIndex].volumeMounts[mountIndex] = {
+      ...newContainers[containerIndex].volumeMounts[mountIndex],
+      [field]: value
+    };
+    updateConfig({ containers: newContainers });
+  };
+
+  const addVolume = () => {
+    updateConfig({
+      volumes: [...config.volumes, { name: '', mountPath: '', type: 'emptyDir' }]
+    });
+  };
+
+  const removeVolume = (index: number) => {
+    updateConfig({
+      volumes: config.volumes.filter((_, i) => i !== index)
+    });
+  };
+
+  const updateVolume = (index: number, field: keyof typeof config.volumes[0], value: any) => {
+    const newVolumes = [...config.volumes];
+    newVolumes[index] = { ...newVolumes[index], [field]: value };
+    updateConfig({ volumes: newVolumes });
+  };
+
+  // ConfigMap and Secret selection functions
+  const toggleConfigMapSelection = (configMapName: string) => {
+    const isSelected = config.selectedConfigMaps.includes(configMapName);
+    if (isSelected) {
+      updateConfig({
+        selectedConfigMaps: config.selectedConfigMaps.filter(name => name !== configMapName)
+      });
+    } else {
+      updateConfig({
+        selectedConfigMaps: [...config.selectedConfigMaps, configMapName]
+      });
+    }
+  };
+
+  const toggleSecretSelection = (secretName: string) => {
+    const isSelected = config.selectedSecrets.includes(secretName);
+    if (isSelected) {
+      updateConfig({
+        selectedSecrets: config.selectedSecrets.filter(name => name !== secretName)
+      });
+    } else {
+      updateConfig({
+        selectedSecrets: [...config.selectedSecrets, secretName]
+      });
+    }
+  };
+
+  const getDefaultMountPath = (volumeName: string, volumeType: string): string => {
+    if (volumeType === 'configMap') {
+      return `/etc/config/${volumeName}`;
+    } else if (volumeType === 'secret') {
+      return `/etc/secrets/${volumeName}`;
+    }
+    return `/data/${volumeName}`;
+  };
+
+  // Node Selector Presets
+  const nodeSelectorPresets = [
+    { key: 'kubernetes.io/os', value: 'linux' },
+    { key: 'kubernetes.io/os', value: 'windows' },
+    { key: 'kubernetes.io/arch', value: 'amd64' },
+    { key: 'kubernetes.io/arch', value: 'arm64' }
+  ];
+  const handlePresetSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = nodeSelectorPresets.find(p => p.key + ':' + p.value === e.target.value);
+    if (selected) {
+      // Only add if not already present
+      if (!nodeSelectorPairs.some(pair => pair.key === selected.key && pair.value === selected.value)) {
+        const newPairs = [...nodeSelectorPairs, { key: selected.key, value: selected.value }];
+        setNodeSelectorPairs(newPairs);
+        syncNodeSelectorToConfig(newPairs);
+      }
+    }
+    // Reset select
+    e.target.selectedIndex = 0;
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Basic Configuration */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center mb-4">
+          <Server className="w-5 h-5 text-blue-600 mr-2" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">DaemonSet Configuration</h3>
+        </div>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              DaemonSet Name *
+            </label>
+            <input
+              type="text"
+              value={config.appName}
+              onChange={(e) => updateConfig({ appName: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="my-daemonset"
+            />
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Namespace
+            </label>
+            <select
+              value={config.namespace}
+              onChange={(e) => updateConfig({ namespace: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+            >
+              {availableNamespaces.map(ns => (
+                <option key={ns} value={ns}>{ns}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Node Selector (inline in config section) */}
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Node Selector (optional)
+          </label>
+          {/* Presets Dropdown */}
+          <select
+            className="mb-2 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm dark:bg-gray-700 dark:text-white"
+            onChange={handlePresetSelect}
+            defaultValue=""
+          >
+            <option value="" disabled>Add preset...</option>
+            {nodeSelectorPresets.map(preset => (
+              <option key={preset.key + ':' + preset.value} value={preset.key + ':' + preset.value}>
+                {preset.key}: {preset.value}
+              </option>
+            ))}
+          </select>
+          {nodeSelectorPairs.length > 0 ? (
+            nodeSelectorPairs.map((pair, idx) => (
+              <div key={idx} className="flex items-center mb-2 space-x-2">
+                <input
+                  type="text"
+                  value={pair.key}
+                  onChange={e => {
+                    const newPairs = [...nodeSelectorPairs];
+                    newPairs[idx] = { ...pair, key: e.target.value };
+                    setNodeSelectorPairs(newPairs);
+                    syncNodeSelectorToConfig(newPairs);
+                  }}
+                  className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm dark:bg-gray-700 dark:text-white"
+                  placeholder="key"
+                />
+                <span>=</span>
+                <input
+                  type="text"
+                  value={pair.value}
+                  onChange={e => {
+                    const newPairs = [...nodeSelectorPairs];
+                    newPairs[idx] = { ...pair, value: e.target.value };
+                    setNodeSelectorPairs(newPairs);
+                    syncNodeSelectorToConfig(newPairs);
+                  }}
+                  className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm dark:bg-gray-700 dark:text-white"
+                  placeholder="value"
+                />
+                <button
+                  type="button"
+                  className="p-1 text-red-600 hover:bg-red-50 rounded transition-colors duration-200"
+                  onClick={() => {
+                    const newPairs = nodeSelectorPairs.filter((_, i) => i !== idx);
+                    setNodeSelectorPairs(newPairs);
+                    syncNodeSelectorToConfig(newPairs);
+                  }}
+                  title="Remove selector"
+                >
+                  <Minus className="w-4 h-4" />
+                </button>
+              </div>
+            ))
+          ) : (
+            <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">No node selectors set.</div>
+          )}
+          <button
+            type="button"
+            className="inline-flex items-center px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs"
+            onClick={() => {
+              const newPairs = [...nodeSelectorPairs, { key: '', value: '' }];
+              setNodeSelectorPairs(newPairs);
+              syncNodeSelectorToConfig(newPairs);
+            }}
+          >
+            <Plus className="w-3 h-3 mr-1" /> Add Node Selector
+          </button>
+        </div>
+      </div>
+
+      {/* Containers */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center">
+            <Database className="w-5 h-5 text-blue-600 mr-2" />
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Containers</h3>
+          </div>
+          <button
+            onClick={addContainer}
+            className="inline-flex items-center px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors duration-200 text-sm"
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            Add Container
+          </button>
+        </div>
+
+        {config.containers.map((container, containerIndex) => (
+          <div key={containerIndex} className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 mb-4">
+            <div className="flex items-center justify-between mb-4">
+              <h4 className="text-md font-medium text-gray-900 dark:text-white">
+                Container {containerIndex + 1}
+              </h4>
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => duplicateContainer(containerIndex)}
+                  className="p-1 text-gray-500 hover:text-blue-600 transition-colors duration-200"
+                  title="Duplicate container"
+                >
+                  <Copy className="w-4 h-4" />
+                </button>
+                {config.containers.length > 1 && (
+                  <button
+                    onClick={() => removeContainer(containerIndex)}
+                    className="p-1 text-gray-500 hover:text-red-600 transition-colors duration-200"
+                    title="Remove container"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Container Name
+                </label>
+                <input
+                  type="text"
+                  value={container.name}
+                  onChange={(e) => updateContainer(containerIndex, { name: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="app"
+                />
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Container Image *
+                </label>
+                <input
+                  type="text"
+                  value={container.image}
+                  onChange={(e) => updateContainer(containerIndex, { image: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="nginx:latest"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Port
+                </label>
+                <input
+                  type="number"
+                  value={container.port || ''}
+                  onChange={(e) => updateContainer(containerIndex, { port: parseInt(e.target.value) || undefined })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="8080"
+                />
+              </div>
+            </div>
+
+            {/* Environment Variables */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-3">
+                <h5 className="text-sm font-medium text-gray-700">Environment Variables</h5>
+                <button
+                  onClick={() => addContainerEnvVar(containerIndex)}
+                  className="inline-flex items-center px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 transition-colors duration-200"
+                >
+                  <Plus className="w-3 h-3 mr-1" />
+                  Add
+                </button>
+              </div>
+              
+              {container.env.length > 0 && (
+                <div className="space-y-3">
+                  {container.env.map((envVar, envIndex) => (
+                    <div key={envIndex} className="border border-gray-200 rounded-lg p-3 bg-white">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">
+                            Variable Name *
+                          </label>
+                          <input
+                            type="text"
+                            value={envVar.name}
+                            onChange={(e) => updateContainerEnvVar(containerIndex, envIndex, { name: e.target.value })}
+                            className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="DATABASE_URL"
+                          />
+                        </div>
+                        
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">
+                            Value Source
+                          </label>
+                          <select
+                            value={envVar.valueFrom ? envVar.valueFrom.type : 'direct'}
+                            onChange={(e) => {
+                              if (e.target.value === 'direct') {
+                                updateContainerEnvVar(containerIndex, envIndex, { 
+                                  value: envVar.value || '',
+                                  valueFrom: undefined 
+                                });
+                              } else {
+                                updateContainerEnvVar(containerIndex, envIndex, { 
+                                  value: undefined,
+                                  valueFrom: { 
+                                    type: e.target.value as 'configMap' | 'secret', 
+                                    name: '', 
+                                    key: '' 
+                                  } 
+                                });
+                              }
+                            }}
+                            className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                          >
+                            <option value="direct">Direct Value</option>
+                            <option value="configMap">ConfigMap</option>
+                            <option value="secret">Secret</option>
+                          </select>
+                        </div>
+                        
+                        {envVar.valueFrom ? (
+                          <>
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">
+                                {envVar.valueFrom.type === 'configMap' ? 'ConfigMap' : 'Secret'} Name
+                              </label>
+                              <select
+                                value={envVar.valueFrom.name}
+                                onChange={(e) => updateContainerEnvVar(containerIndex, envIndex, { 
+                                  valueFrom: { ...envVar.valueFrom!, name: e.target.value } 
+                                })}
+                                className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                              >
+                                <option value="">Select {envVar.valueFrom.type}</option>
+                                {envVar.valueFrom.type === 'configMap' 
+                                  ? filteredConfigMaps.map(cm => (
+                                      <option key={cm.name} value={cm.name}>{cm.name}</option>
+                                    ))
+                                  : filteredSecrets.map(s => (
+                                      <option key={s.name} value={s.name}>{s.name}</option>
+                                    ))
+                                }
+                              </select>
+                            </div>
+                            
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">
+                                Key
+                              </label>
+                              <select
+                                value={envVar.valueFrom.key}
+                                onChange={(e) => updateContainerEnvVar(containerIndex, envIndex, { 
+                                  valueFrom: { ...envVar.valueFrom!, key: e.target.value } 
+                                })}
+                                className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                                disabled={!envVar.valueFrom.name}
+                              >
+                                <option value="">Select key</option>
+                                {envVar.valueFrom.name && (
+                                  envVar.valueFrom.type === 'configMap' 
+                                    ? filteredConfigMaps.find(cm => cm.name === envVar.valueFrom!.name)?.data && 
+                                      Object.keys(filteredConfigMaps.find(cm => cm.name === envVar.valueFrom!.name)!.data).map(key => (
+                                        <option key={key} value={key}>{key}</option>
+                                      ))
+                                    : filteredSecrets.find(s => s.name === envVar.valueFrom!.name)?.data && 
+                                      Object.keys(filteredSecrets.find(s => s.name === envVar.valueFrom!.name)!.data).map(key => (
+                                        <option key={key} value={key}>{key}</option>
+                                      ))
+                                )}
+                              </select>
+                            </div>
+                          </>
+                        ) : (
+                          <div className="sm:col-span-2">
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                              Value
+                            </label>
+                            <input
+                              type="text"
+                              value={envVar.value || ''}
+                              onChange={(e) => updateContainerEnvVar(containerIndex, envIndex, { value: e.target.value })}
+                              className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                              placeholder="environment value"
+                            />
+                          </div>
+                        )}
+                      </div>
+                      
+                      <div className="flex justify-end">
+                        <button
+                          onClick={() => removeContainerEnvVar(containerIndex, envIndex)}
+                          className="p-1 text-red-600 hover:bg-red-50 rounded transition-colors duration-200"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Volume Mounts */}
+            <div className="mb-4">
+              <div className="flex items-center justify-between mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Volume Mounts
+                </label>
+                <button
+                  onClick={() => addContainerVolumeMount(containerIndex)}
+                  className="inline-flex items-center px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-sm hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200"
+                >
+                  <Plus className="w-3 h-3 mr-1" />
+                  Add
+                </button>
+              </div>
+              
+              {container.volumeMounts.map((mount, mountIndex) => (
+                <div key={mountIndex} className="flex items-center space-x-2 mb-2">
+                  <input
+                    type="text"
+                    value={mount.name}
+                    onChange={(e) => updateContainerVolumeMount(containerIndex, mountIndex, 'name', e.target.value)}
+                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="Volume name"
+                  />
+                  <input
+                    type="text"
+                    value={mount.mountPath}
+                    onChange={(e) => updateContainerVolumeMount(containerIndex, mountIndex, 'mountPath', e.target.value)}
+                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="/path/to/mount"
+                  />
+                  <button
+                    onClick={() => removeContainerVolumeMount(containerIndex, mountIndex)}
+                    className="p-2 text-gray-500 hover:text-red-600 transition-colors duration-200"
+                  >
+                    <Minus className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {/* Resources */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Resource Requirements
+              </label>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    CPU Request
+                  </label>
+                  <input
+                    type="text"
+                    value={container.resources.requests.cpu}
+                    onChange={(e) => updateContainer(containerIndex, {
+                      resources: {
+                        ...container.resources,
+                        requests: { ...container.resources.requests, cpu: e.target.value }
+                      }
+                    })}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="100m"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    Memory Request
+                  </label>
+                  <input
+                    type="text"
+                    value={container.resources.requests.memory}
+                    onChange={(e) => updateContainer(containerIndex, {
+                      resources: {
+                        ...container.resources,
+                        requests: { ...container.resources.requests, memory: e.target.value }
+                      }
+                    })}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="128Mi"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    CPU Limit
+                  </label>
+                  <input
+                    type="text"
+                    value={container.resources.limits.cpu}
+                    onChange={(e) => updateContainer(containerIndex, {
+                      resources: {
+                        ...container.resources,
+                        limits: { ...container.resources.limits, cpu: e.target.value }
+                      }
+                    })}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="500m"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    Memory Limit
+                  </label>
+                  <input
+                    type="text"
+                    value={container.resources.limits.memory}
+                    onChange={(e) => updateContainer(containerIndex, {
+                      resources: {
+                        ...container.resources,
+                        limits: { ...container.resources.limits, memory: e.target.value }
+                      }
+                    })}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                    placeholder="256Mi"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Service Configuration */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center mb-4">
+          <Globe className="w-5 h-5 text-blue-600 mr-2" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Service Configuration</h3>
+        </div>
+        
+        {/* Service Toggle */}
+        <div className="mb-4">
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={config.serviceEnabled}
+              onChange={(e) => updateConfig({ serviceEnabled: e.target.checked })}
+              className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+            />
+            <span className="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              Expose DaemonSet as a Service
+            </span>
+          </label>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Enable this to create a Service that exposes the DaemonSet pods
+          </p>
+        </div>
+        
+        {config.serviceEnabled && (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Service Port
+              </label>
+              <input
+                type="number"
+                value={config.port}
+                onChange={(e) => updateConfig({ port: parseInt(e.target.value) || 80 })}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Target Port
+              </label>
+              <input
+                type="number"
+                value={config.targetPort}
+                onChange={(e) => updateConfig({ targetPort: parseInt(e.target.value) || 8080 })}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Service Type
+              </label>
+              <select
+                value={config.serviceType}
+                onChange={(e) => updateConfig({ serviceType: e.target.value as any })}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              >
+                <option value="ClusterIP">ClusterIP</option>
+                <option value="NodePort">NodePort</option>
+                <option value="LoadBalancer">LoadBalancer</option>
+              </select>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Volumes */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center">
+            <FileText className="w-5 h-5 text-blue-600 mr-2" />
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Volumes</h3>
+          </div>
+          <button
+            onClick={addVolume}
+            className="inline-flex items-center px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors duration-200 text-sm"
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            Add Volume
+          </button>
+        </div>
+
+        {config.volumes.map((volume, index) => (
+          <div key={index} className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 mb-4">
+            <div className="flex items-center justify-between mb-4">
+              <h4 className="text-md font-medium text-gray-900 dark:text-white">
+                Volume {index + 1}
+              </h4>
+              <button
+                onClick={() => removeVolume(index)}
+                className="p-1 text-gray-500 hover:text-red-600 transition-colors duration-200"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Volume Name
+                </label>
+                <input
+                  type="text"
+                  value={volume.name}
+                  onChange={(e) => updateVolume(index, 'name', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="my-volume"
+                />
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Volume Type
+                </label>
+                <select
+                  value={volume.type}
+                  onChange={(e) => updateVolume(index, 'type', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value="emptyDir">Empty Directory</option>
+                  <option value="configMap">ConfigMap</option>
+                  <option value="secret">Secret</option>
+                </select>
+              </div>
+            </div>
+
+            {volume.type === 'configMap' && (
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  ConfigMap Name
+                </label>
+                <select
+                  value={volume.configMapName || ''}
+                  onChange={(e) => updateVolume(index, 'configMapName', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value="">Select ConfigMap</option>
+                  {filteredConfigMaps.map(cm => (
+                    <option key={cm.name} value={cm.name}>{cm.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {volume.type === 'secret' && (
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Secret Name
+                </label>
+                <select
+                  value={volume.secretName || ''}
+                  onChange={(e) => updateVolume(index, 'secretName', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value="">Select Secret</option>
+                  {filteredSecrets.map(secret => (
+                    <option key={secret.name} value={secret.name}>{secret.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Mount Path
+              </label>
+              <input
+                type="text"
+                value={volume.mountPath}
+                onChange={(e) => updateVolume(index, 'mountPath', e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                placeholder={getDefaultMountPath(volume.name, volume.type)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ConfigMaps and Secrets Selection */}
+      {(filteredConfigMaps.length > 0 || filteredSecrets.length > 0) && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center mb-4">
+            <Key className="w-5 h-5 text-blue-600 mr-2" />
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Available ConfigMaps & Secrets</h3>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {filteredConfigMaps.length > 0 && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  ConfigMaps
+                </label>
+                <div className="space-y-2">
+                  {filteredConfigMaps.map(configMap => (
+                    <label key={configMap.name} className="flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={config.selectedConfigMaps.includes(configMap.name)}
+                        onChange={() => toggleConfigMapSelection(configMap.name)}
+                        className="mr-2"
+                      />
+                      <span className="text-sm text-gray-700 dark:text-gray-300">{configMap.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+            
+            {filteredSecrets.length > 0 && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Secrets
+                </label>
+                <div className="space-y-2">
+                  {filteredSecrets.map(secret => (
+                    <label key={secret.name} className="flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={config.selectedSecrets.includes(secret.name)}
+                        onChange={() => toggleSecretSelection(secret.name)}
+                        className="mr-2"
+                      />
+                      <span className="text-sm text-gray-700 dark:text-gray-300">{secret.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/src/components/DaemonSetsList.tsx
+++ b/src/components/DaemonSetsList.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from 'react';
+import { Settings, Copy, Trash2, AlertTriangle, Database, Globe } from 'lucide-react';
+import type { DaemonSetConfig } from '../types';
+
+interface DaemonSetsListProps {
+  daemonSets: DaemonSetConfig[];
+  selectedDaemonSet: number;
+  onSelectDaemonSet: (index: number) => void;
+  onEditDaemonSet: (index: number) => void;
+  onDuplicateDaemonSet: (index: number) => void;
+  onDeleteDaemonSet: (index: number) => void;
+}
+
+export function DaemonSetsList({
+  daemonSets,
+  selectedDaemonSet,
+  onSelectDaemonSet,
+  onEditDaemonSet,
+  onDuplicateDaemonSet,
+  onDeleteDaemonSet
+}: DaemonSetsListProps) {
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  const handleDeleteClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(index);
+  };
+
+  const handleConfirmDelete = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDeleteDaemonSet(index);
+    setDeleteConfirm(null);
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirm(null);
+  };
+
+  const handleDuplicateClick = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDuplicateDaemonSet(index);
+  };
+
+  const getDaemonSetSummary = (daemonSet: DaemonSetConfig) => {
+    const containerCount = daemonSet.containers?.length || 0;
+    const primaryImage = daemonSet.containers?.[0]?.image || daemonSet.image || 'No image specified';
+    const hasMultipleContainers = containerCount > 1;
+    const hasService = daemonSet.serviceEnabled;
+    return {
+      containerCount,
+      primaryImage,
+      hasMultipleContainers,
+      hasService
+    };
+  };
+
+  if (daemonSets.length === 0) {
+    return (
+      <div className="p-6 text-center">
+        <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <Database className="w-8 h-8 text-gray-400" />
+        </div>
+        <h3 className="text-lg font-medium text-gray-900 mb-2">No DaemonSets</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Get started by creating your first Kubernetes DaemonSet
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1 p-4">
+      {daemonSets.map((daemonSet, index) => {
+        const summary = getDaemonSetSummary(daemonSet);
+        return (
+          <div
+            key={index}
+            className={`p-3 rounded-lg border cursor-pointer transition-all duration-200 ${
+              selectedDaemonSet === index
+                ? 'bg-blue-50 border-blue-200 ring-1 ring-blue-200'
+                : 'bg-white border-gray-200 hover:bg-gray-50'
+            }`}
+            onClick={() => onSelectDaemonSet(index)}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3 min-w-0 flex-1">
+                <div className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                  daemonSet.appName ? 'bg-green-500' : 'bg-gray-300'
+                }`} />
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium text-gray-900 truncate">
+                    {daemonSet.appName || `DaemonSet ${index + 1}`}
+                  </div>
+                  <div className="text-sm text-gray-500 truncate">
+                    {summary.primaryImage}
+                  </div>
+                  <div className="flex items-center space-x-2 mt-1">
+                    {summary.hasMultipleContainers && (
+                      <div className="flex items-center space-x-1">
+                        <Database className="w-3 h-3 text-purple-500" />
+                        <span className="text-xs text-purple-600">
+                          {summary.containerCount} containers
+                        </span>
+                      </div>
+                    )}
+                    {summary.hasService && (
+                      <div className="flex items-center space-x-1">
+                        <Globe className="w-3 h-3 text-green-500" />
+                        <span className="text-xs text-green-600">
+                          Service: {daemonSet.serviceType}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              {/* Action Buttons */}
+              <div className="flex items-center space-x-1 flex-shrink-0">
+                {deleteConfirm === index ? (
+                  // Delete confirmation buttons
+                  <div className="flex items-center space-x-1">
+                    <button
+                      onClick={handleCancelDelete}
+                      className="px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded hover:bg-gray-200 transition-colors duration-200"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={(e) => handleConfirmDelete(index, e)}
+                      className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 transition-colors duration-200 flex items-center space-x-1"
+                    >
+                      <AlertTriangle className="w-3 h-3" />
+                      <span>Delete</span>
+                    </button>
+                  </div>
+                ) : (
+                  // Normal action buttons
+                  <>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectDaemonSet(index);
+                        onEditDaemonSet(index);
+                      }}
+                      className="p-1 text-gray-400 hover:text-gray-600 rounded transition-colors duration-200"
+                      title="Edit DaemonSet"
+                    >
+                      <Settings className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={(e) => handleDuplicateClick(index, e)}
+                      className="p-1 text-gray-400 hover:text-blue-600 rounded transition-colors duration-200"
+                      title="Duplicate DaemonSet"
+                    >
+                      <Copy className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={(e) => handleDeleteClick(index, e)}
+                      className="p-1 text-gray-400 hover:text-red-600 rounded transition-colors duration-200"
+                      title="Delete DaemonSet"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+            {/* Delete confirmation warning */}
+            {deleteConfirm === index && (
+              <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">
+                <div className="flex items-center space-x-1 mb-1">
+                  <AlertTriangle className="w-3 h-3" />
+                  <span className="font-medium">Are you sure?</span>
+                </div>
+                <div>
+                  {daemonSets.length === 1
+                    ? 'This will reset the DaemonSet to default values.'
+                    : 'This action cannot be undone.'
+                  }
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+} 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,6 +93,31 @@ export interface DeploymentConfig {
   };
 }
 
+export interface DaemonSetConfig {
+  appName: string;
+  containers: Container[];
+  serviceEnabled: boolean;
+  port: number;
+  targetPort: number;
+  serviceType: 'ClusterIP' | 'NodePort' | 'LoadBalancer';
+  namespace: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  volumes: Array<{ name: string; mountPath: string; type: 'emptyDir' | 'configMap' | 'secret'; configMapName?: string; secretName?: string }>;
+  configMaps: Array<{ name: string; data: Record<string, string> }>; // Legacy - for backward compatibility
+  secrets: Array<{ name: string; data: Record<string, string> }>; // Legacy - for backward compatibility
+  selectedConfigMaps: string[]; // References to ConfigMap names
+  selectedSecrets: string[]; // References to Secret names
+  nodeSelector?: Record<string, string>; // Optional node selector
+  // Legacy fields for backward compatibility
+  image?: string;
+  env?: Array<{ name: string; value: string }>;
+  resources?: {
+    requests: { cpu: string; memory: string };
+    limits: { cpu: string; memory: string };
+  };
+}
+
 export interface Namespace {
   name: string;
   labels: Record<string, string>;


### PR DESCRIPTION
## Add Node Selector Support with Presets to DaemonSet Form

### Summary

This PR adds support for configuring Kubernetes `nodeSelector` in the DaemonSet creation form. Users can now:

- **Add, edit, or remove custom nodeSelector key-value pairs** directly in the DaemonSet modal.
- **Quickly insert standard Kubernetes nodeSelector presets** (such as OS and architecture) from a dropdown menu:
  - `kubernetes.io/os: linux`
  - `kubernetes.io/os: windows`
  - `kubernetes.io/arch: amd64`
  - `kubernetes.io/arch: arm64`
- **Mix and match presets and custom selectors** as needed.

### Details

- The Node Selector UI is integrated into the DaemonSet Configuration section of the modal.
- Presets are added via a dropdown and will not duplicate existing entries.
- All nodeSelector changes are reflected in the generated YAML.
- The UI/UX is non-intrusive and matches the style of the rest of the form.

