### PR TITLE
fix emtpy request and limit

### DIFF
--- a/src/components/DaemonSetForm.tsx
+++ b/src/components/DaemonSetForm.tsx
@@ -52,7 +52,7 @@ export function DaemonSetForm({ config, onChange, availableNamespaces, available
       port: 8080,
       env: [],
       resources: {
-        requests: { cpu: '', memory: '' },
+        requests: { cpu: '100m', memory: '128Mi' },
         limits: { cpu: '', memory: '' }
       },
       volumeMounts: []
@@ -74,9 +74,18 @@ export function DaemonSetForm({ config, onChange, availableNamespaces, available
     const containerToDuplicate = config.containers[index];
     const duplicatedContainer: Container = {
       ...containerToDuplicate,
-      name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : ''
+      name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : '',
+      resources: {
+        requests: {
+          cpu: containerToDuplicate.resources.requests.cpu || '100m',
+          memory: containerToDuplicate.resources.requests.memory || '128Mi'
+        },
+        limits: {
+          cpu: '',
+          memory: ''
+        }
+      }
     };
-    
     const newContainers = [...config.containers];
     newContainers.splice(index + 1, 0, duplicatedContainer);
     updateConfig({ containers: newContainers });

--- a/src/components/DeploymentForm.tsx
+++ b/src/components/DeploymentForm.tsx
@@ -22,7 +22,7 @@ export function DeploymentForm({ config, onChange, availableNamespaces, availabl
       port: 8080,
       env: [],
       resources: {
-        requests: { cpu: '', memory: '' },
+        requests: { cpu: '100m', memory: '128Mi' },
         limits: { cpu: '', memory: '' }
       },
       volumeMounts: []
@@ -44,9 +44,18 @@ export function DeploymentForm({ config, onChange, availableNamespaces, availabl
     const containerToDuplicate = config.containers[index];
     const duplicatedContainer: Container = {
       ...containerToDuplicate,
-      name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : ''
+      name: containerToDuplicate.name ? `${containerToDuplicate.name}-copy` : '',
+      resources: {
+        requests: {
+          cpu: containerToDuplicate.resources.requests.cpu || '100m',
+          memory: containerToDuplicate.resources.requests.memory || '128Mi'
+        },
+        limits: {
+          cpu: '',
+          memory: ''
+        }
+      }
     };
-    
     const newContainers = [...config.containers];
     newContainers.splice(index + 1, 0, duplicatedContainer);
     updateConfig({ containers: newContainers });


### PR DESCRIPTION
## Resource Requests and Limits Handling

- **Default Requests:** All new containers now default to `cpu: 100m` and `memory: 128Mi` for resource requests. These values are pre-filled in the form and will always be included in the generated YAML unless changed by the user.
- **Limits Are Optional:** Resource limits (CPU and memory) are left blank by default. If the user does not specify a value for either limit, the `limits` section will be omitted from the generated YAML for that container.
- **YAML Output:** The YAML generator only includes the `limits` field if at least one of the limit values is set by the user. This ensures that unnecessary or zero-value limits are not present in the output, resulting in cleaner and more accurate manifests.
