### PR TITLE
Ingress Annotations Input Fix

### DIFF
--- a/src/components/DeploymentForm.tsx
+++ b/src/components/DeploymentForm.tsx
@@ -199,15 +199,6 @@ export function DeploymentForm({ config, onChange, availableNamespaces, availabl
     updateIngress({ annotations: newAnnotations });
   };
 
-  const updateIngressAnnotation = (oldKey: string, newKey: string, value: string) => {
-    const newAnnotations = { ...config.ingress.annotations };
-    if (oldKey !== newKey) {
-      delete newAnnotations[oldKey];
-    }
-    newAnnotations[newKey] = value;
-    updateIngress({ annotations: newAnnotations });
-  };
-
   const updateIngressAnnotationKey = (oldKey: string, newKey: string) => {
     const newAnnotations = { ...config.ingress.annotations };
     if (oldKey !== newKey) {

--- a/src/components/DeploymentForm.tsx
+++ b/src/components/DeploymentForm.tsx
@@ -208,6 +208,22 @@ export function DeploymentForm({ config, onChange, availableNamespaces, availabl
     updateIngress({ annotations: newAnnotations });
   };
 
+  const updateIngressAnnotationKey = (oldKey: string, newKey: string) => {
+    const newAnnotations = { ...config.ingress.annotations };
+    if (oldKey !== newKey) {
+      const value = newAnnotations[oldKey];
+      delete newAnnotations[oldKey];
+      newAnnotations[newKey] = value;
+      updateIngress({ annotations: newAnnotations });
+    }
+  };
+
+  const updateIngressAnnotationValue = (key: string, value: string) => {
+    const newAnnotations = { ...config.ingress.annotations };
+    newAnnotations[key] = value;
+    updateIngress({ annotations: newAnnotations });
+  };
+
   const addIngressTLS = () => {
     updateIngress({
       tls: [...config.ingress.tls, {
@@ -965,19 +981,19 @@ export function DeploymentForm({ config, onChange, availableNamespaces, availabl
               
               {Object.entries(config.ingress.annotations).length > 0 && (
                 <div className="space-y-2">
-                  {Object.entries(config.ingress.annotations).map(([key, value]) => (
-                    <div key={key} className="flex items-center space-x-2">
+                  {Object.entries(config.ingress.annotations).map(([key, value], idx) => (
+                    <div key={idx} className="flex items-center space-x-2">
                       <input
                         type="text"
                         value={key}
-                        onChange={(e) => updateIngressAnnotation(key, e.target.value, value)}
+                        onChange={(e) => updateIngressAnnotationKey(key, e.target.value)}
                         className="flex-1 px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-orange-500 focus:border-transparent text-sm"
                         placeholder="nginx.ingress.kubernetes.io/rewrite-target"
                       />
                       <input
                         type="text"
                         value={value}
-                        onChange={(e) => updateIngressAnnotation(key, key, e.target.value)}
+                        onChange={(e) => updateIngressAnnotationValue(key, e.target.value)}
                         className="flex-1 px-2 py-1 border border-gray-300 rounded focus:ring-1 focus:ring-orange-500 focus:border-transparent text-sm"
                         placeholder="/"
                       />


### PR DESCRIPTION
### Ingress Annotations Input Fix
**Problem**:
When typing in the Ingress Annotations fields, the input would lose focus or become unresponsive after entering just one character. This was because the React key for each annotation row was set to the annotation key itself, causing React to recreate the input field on every keystroke.
**Solution**:
We changed the React key for each annotation row to use the array index instead of the annotation key. This ensures the input fields remain stable in the DOM, allowing users to type freely without losing focus or getting stuck.
**Result**:
You can now type multiple characters in both the key and value fields for Ingress Annotations without any issues.