### PR TITLE
fix input type issue and invalid fields removed for ingress

### DIFF
--- a/src/utils/yamlGenerator.ts
+++ b/src/utils/yamlGenerator.ts
@@ -113,8 +113,6 @@ export function generateKubernetesYaml(config: DeploymentConfig, projectSettings
             paths: [{
               path: rule.path,
               pathType: rule.pathType,
-              serviceName: rule.serviceName,
-              servicePort: rule.servicePort,
               backend: {
                 service: {
                   name: rule.serviceName,


### PR DESCRIPTION
**Ingress annotations input :** 

Now the ingress annotations inputs should work properly. 

**Ingress Issue :**
1. ❌ Invalid Fields Removed:
    - serviceName: rule.serviceName (not part of networking.k8s.io/v1 API)
    - servicePort: rule.servicePort (not part of networking.k8s.io/v1 API)
  2. ✅ Now API-Compliant:
  paths:
  - path: /
    pathType: Prefix
    backend:
      service:
        name: service-name
        port:
          number: 80
